### PR TITLE
Disambiguate something in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Installation:
 
 Parameters:
 ===========
-* --reruns=N    reruns failing tests N times (default 0)
+* --reruns=N    rerun each failing test up to N times (default 0)
 * -r R          reports on which tests were rerun (optional, may be combined with sxXF)
 
 Notes:


### PR DESCRIPTION
Change phrasing of description of `--reruns=N` parameter in the README. Its previous phrasing referred to rerunning "failing tests N times" and the phrasing made it ambiguous whether "N" is a shared count, or a per-test count. Indeed, it reruns _each_ test, _up to_ N times. This commit attempts to make that completely clear.

Fixes Issue #11
