### PR TITLE
Add Framework::Pytest to list of classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(name='pytest-rerunfailures',
       keywords='py.test pytest rerun failures flaky',
       classifiers=[
           'Development Status :: 5 - Production/Stable',
+          'Framework :: Pytest',
           'Intended Audience :: Developers',
           'License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)',
           'Operating System :: POSIX',


### PR DESCRIPTION
After merging someone with the necessary access will need to run `python setup.py register` to update the package on PyPI.