### PR TITLE
Pass a type instead of string to parser.addoption

### DIFF
--- a/pytest_rerunfailures.py
+++ b/pytest_rerunfailures.py
@@ -13,7 +13,7 @@ def pytest_addoption(parser):
         '--reruns',
         action="store",
         dest="reruns",
-        type="int",
+        type=int,
         default=0,
         help="number of times to re-run failed tests. defaults to 0.")
 


### PR DESCRIPTION
Otherwise we get this DeprecationWarning with pytest 3.0:

      [...]
      File ".../pytest_rerunfailures.py", line 18, in pytest_addoption
        help="number of times to re-run failed tests. defaults to 0.")
      File ".../_pytest/config.py", line 482, in addoption
        self._anonymous.addoption(*opts, **attrs)
      File ".../_pytest/config.py", line 708, in addoption
        option = Argument(*optnames, **attrs)
      File ".../_pytest/config.py", line 609, in __init__
        stacklevel=3)
    DeprecationWarning: type argument to addoption() is a string 'int'. For parsearg this should be a type. (options: ('--reruns',))