### PR TITLE
Fix #35. Add MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+include *.py
+include *.rst
+include LICENSE
+include tox.ini


### PR DESCRIPTION
created with `check-manifest -c`

Fix for https://github.com/pytest-dev/pytest-rerunfailures/issues/35