### PR TITLE
Skip if item.session.config.option.reruns is 0

### DIFF
--- a/pytest_rerunfailures.py
+++ b/pytest_rerunfailures.py
@@ -57,7 +57,7 @@ def pytest_runtest_protocol(item, nextitem):
             reruns = rerun_marker.args[0]
         else:
             reruns = 1
-    elif item.session.config.option.reruns is not None:
+    elif item.session.config.option.reruns:
         # default to the global setting
         reruns = item.session.config.option.reruns
     else:


### PR DESCRIPTION
`pytest_runtest_protocol` returns `True` even though we don't mark as "should be rerun".  Because the default value of `item.session.config.option.reruns` is `0` not `None`.  This behavior prevents to run `pytest_runtest_protocol` in other plugins.