### PR TITLE
Add support for pytest-xdist

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -82,9 +82,7 @@ Here's an example of the output provided by the plugin when run with
   ======================= 1 failed, 2 rerun in 0.02 seconds ====================
 
 Note that output will show all re-runs. Tests that fail on all the re-runs will
-be marked as failed. Due to a
-`current limitation in pytest-xdist <https://github.com/pytest-dev/pytest/issues/1193>`_,
-when running tests in parallel only the final result will be included in the output.
+be marked as failed.
 
 Compatibility
 -------------


### PR DESCRIPTION
Thanks to @nicoddemus' fix in https://github.com/pytest-dev/pytest-xdist/pull/218 we can now log reruns when using pytest-xdist. If users have an older version of pytest-xdist then they'll see the same behaviour as before, but as soon as they upgrade they'll get the additional log entries.