### PR TITLE
Adding delay time between reruns, PR for #42

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .DS_Store
 .Python
 .cache/
+.idea/
 .python-version
 .tox*
 bin/

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ env:
   - PYTEST=3.0.7
   - PYTEST=3.1.3
   - PYTEST=3.2.1
+  - PYTEST=3.3.1
 install:
   - pip install -q pytest==$PYTEST
   - pip install -q -e .

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ python:
   - pypy
   - pypy3.5-5.8.0
 env:
-  - PYTEST=2.7.3
   - PYTEST=2.8.7
   - PYTEST=2.9.2
   - PYTEST=3.0.7

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,10 +5,12 @@ Changelog
 3.2 (unreleased)
 ================
 
-- Added option to add a delay time between test re-runs (Thank to `@Kanguos`_
+- Added option to add a delay time between test re-runs (Thanks to `@Kanguos`_
   for the PR).
 
 - Added support for pytest >= 3.3.
+
+.. _@Kanguros: https://github.com/Kanguros
 
 
 3.1 (2017-08-29)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,10 @@ Changelog
 3.2 (unreleased)
 ================
 
-- Nothing changed yet.
+- Added option to add a delay time between test re-runs (Thank to `@Kanguos`_
+  for the PR).
+
+- Added support for pytest >= 3.3.
 
 
 3.1 (2017-08-29)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changelog
 3.2 (unreleased)
 ================
 
-- Added option to add a delay time between test re-runs (Thanks to `@Kanguos`_
+- Added option to add a delay time between test re-runs (Thanks to `@Kanguros`_
   for the PR).
 
 - Added support for pytest >= 3.3.

--- a/README.rst
+++ b/README.rst
@@ -42,8 +42,8 @@ maximum number of times you'd like the tests to run:
   $ pytest --reruns 5
 
 To add a delay time between re-runs use the ``--reruns-delay`` command line
-option with amount of seconds that you would like wait before the next test
-re-run is lunched:
+option with the amount of seconds that you would like wait before the next
+test re-run is launched:
 
 .. code-block:: bash
 
@@ -66,7 +66,7 @@ test to run:
 Note that when teardown fails, two reports are generated for the case, one for
 the test case and the other for the teardown error.
 
-You can also add a delay time in the marker:
+You can also specify the re-run delay time in the marker:
 
 .. code-block:: python
 

--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ Requirements
 You will need the following prerequisites in order to use pytest-rerunfailures:
 
 - Python 2.7, 3.4, 3.5, 3.6, PyPy, or PyPy3
-- py.test 2.7.3 or newer
+- pytest 2.7.3 or newer
 
 Installation
 ------------
@@ -39,7 +39,15 @@ maximum number of times you'd like the tests to run:
 
 .. code-block:: bash
 
-  $ py.test --rerun 5
+  $ pytest --reruns 5
+
+To add a delay time between re-runs use the ``--reruns-delay`` command line
+option with amount of seconds that you would like wait before the next test
+re-run is lunched:
+
+.. code-block:: bash
+
+   $ pytest --reruns 5 --reruns-delay 1
 
 Re-run individual failures
 --------------------------
@@ -57,6 +65,15 @@ test to run:
 
 Note that when teardown fails, two reports are generated for the case, one for
 the test case and the other for the teardown error.
+
+You can also add a delay time in the marker:
+
+.. code-block:: python
+
+  @pytest.mark.flaky(reruns=5, reruns_delay=2)
+  def test_example():
+      import random
+      assert random.choice([True, False])
 
 Output
 ------

--- a/pytest_rerunfailures.py
+++ b/pytest_rerunfailures.py
@@ -1,5 +1,6 @@
 import pkg_resources
 import time
+import warnings
 
 import pytest
 
@@ -104,6 +105,11 @@ def get_reruns_delay(item):
             delay = 0
     else:
         delay = item.session.config.option.reruns_delay
+
+    if delay < 0:
+        delay = 0
+        warnings.warn('Delay time between re-runs cannot be < 0. '
+                      'Using default value: 0')
 
     return delay
 

--- a/pytest_rerunfailures.py
+++ b/pytest_rerunfailures.py
@@ -48,7 +48,9 @@ def pytest_addoption(parser):
 def pytest_configure(config):
     # add flaky marker
     config.addinivalue_line(
-        "markers", "flaky(reruns=1): mark test to re-run up to 'reruns' times")
+        "markers", "flaky(reruns=1, reruns_delay=0): mark test to re-run up "
+                   "to 'reruns' times. Add a delay of 'reruns_delay' seconds "
+                   "between re-runs.")
 
 
 # making sure the options make sense
@@ -68,7 +70,7 @@ def check_options(config):
         config.pluginmanager.register(config._resultlog)
 
 
-def reruns_count(item):
+def get_reruns_count(item):
     rerun_marker = item.get_marker("flaky")
     reruns = None
 
@@ -89,7 +91,7 @@ def reruns_count(item):
     return reruns
 
 
-def reruns_delay(item):
+def get_reruns_delay(item):
     rerun_marker = item.get_marker("flaky")
 
     if rerun_marker is not None:
@@ -112,7 +114,7 @@ def pytest_runtest_protocol(item, nextitem):
     the test case and the other for the teardown error.
     """
 
-    reruns = reruns_count(item)
+    reruns = get_reruns_count(item)
     if reruns is None:
         # global setting is not specified, and this test is not marked with
         # flaky
@@ -121,7 +123,7 @@ def pytest_runtest_protocol(item, nextitem):
     # while this doesn't need to be run with every item, it will fail on the
     # first item if necessary
     check_options(item.session.config)
-    delay = reruns_delay(item)
+    delay = get_reruns_delay(item)
     parallel = hasattr(item.config, 'slaveinput')
 
     for i in range(reruns + 1):  # ensure at least one run of each item

--- a/pytest_rerunfailures.py
+++ b/pytest_rerunfailures.py
@@ -1,4 +1,5 @@
 import pkg_resources
+import time
 
 import pytest
 
@@ -34,6 +35,14 @@ def pytest_addoption(parser):
         type=int,
         default=0,
         help="number of times to re-run failed tests. defaults to 0.")
+    group._addoption(
+        '--reruns-delay',
+        action='store',
+        dest='reruns_delay',
+        type=float,
+        default=0,
+        help='add time (seconds) delay between reruns.'
+    )
 
 
 def pytest_configure(config):
@@ -103,6 +112,8 @@ def pytest_runtest_protocol(item, nextitem):
             else:
                 # failure detected and reruns not exhausted, since i < reruns
                 report.outcome = 'rerun'
+
+                time.sleep(item.session.config.option.reruns_delay)
 
                 if not parallel or works_with_current_xdist():
                     # will rerun test, log intermediate result

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(name='pytest-rerunfailures',
       url='https://github.com/pytest-dev/pytest-rerunfailures',
       py_modules=['pytest_rerunfailures'],
       entry_points={'pytest11': ['rerunfailures = pytest_rerunfailures']},
-      install_requires=['pytest >= 2.7.3'],
+      install_requires=['pytest >= 2.8.7'],
       license='Mozilla Public License 2.0 (MPL 2.0)',
       keywords='py.test pytest rerun failures flaky',
       classifiers=[

--- a/test_pytest_rerunfailures.py
+++ b/test_pytest_rerunfailures.py
@@ -182,7 +182,7 @@ def test_verbose(testdir):
         def test_pass():
             {0}""".format(temporary_failure()))
     result = testdir.runpytest('--reruns', '1', '-v')
-    result.stdout.fnmatch_lines_random(['test_*:* RERUN'])
+    result.stdout.fnmatch_lines_random(['test_*:* RERUN*'])
     assert '1 rerun' in result.stdout.str()
 
 

--- a/test_pytest_rerunfailures.py
+++ b/test_pytest_rerunfailures.py
@@ -233,3 +233,20 @@ def test_reruns_with_delay(testdir, delay_time):
                                '--reruns-delay', delay_time)
 
     assert_outcomes(result, passed=0, failed=1, rerun=3)
+
+
+def test_reruns_with_delay_marker(testdir):
+    testdir.makepyfile("""
+        import pytest
+        
+        @pytest.mark.flaky(reruns_delay=1)
+        def test_fail_one():
+            assert False
+            
+        @pytest.mark.flaky(reruns=2, reruns_delay=1)
+        def test_fail_two():
+            assert False""")
+
+    result = testdir.runpytest()
+
+    assert_outcomes(result, passed=0, failed=2, rerun=3)

--- a/test_pytest_rerunfailures.py
+++ b/test_pytest_rerunfailures.py
@@ -229,8 +229,8 @@ def test_rerun_with_resultslog(testdir):
     assert_outcomes(result, passed=0, failed=1, rerun=2)
 
 
-@pytest.mark.parametrize('delay_time', [0, 0.0, 1, 2.5])
-def test_reruns_with_delay(testdir, delay_time, monkeypatch):
+@pytest.mark.parametrize('delay_time', [-1, 0, 0.0, 1, 2.5])
+def test_reruns_with_delay(testdir, delay_time):
     testdir.makepyfile("""
         def test_fail():
             assert False""")
@@ -240,12 +240,15 @@ def test_reruns_with_delay(testdir, delay_time, monkeypatch):
     result = testdir.runpytest('--reruns', '3',
                                '--reruns-delay', delay_time)
 
+    if delay_time < 0:
+        delay_time = 0
+
     time.sleep.assert_called_with(delay_time)
 
     assert_outcomes(result, passed=0, failed=1, rerun=3)
 
 
-@pytest.mark.parametrize('delay_time', [0, 0.0, 1, 2.5])
+@pytest.mark.parametrize('delay_time', [-1, 0, 0.0, 1, 2.5])
 def test_reruns_with_delay_marker(testdir, delay_time):
     testdir.makepyfile("""
         import pytest
@@ -257,6 +260,9 @@ def test_reruns_with_delay_marker(testdir, delay_time):
     time.sleep = mock.MagicMock()
 
     result = testdir.runpytest()
+
+    if delay_time < 0:
+        delay_time = 0
 
     time.sleep.assert_called_with(delay_time)
 

--- a/test_pytest_rerunfailures.py
+++ b/test_pytest_rerunfailures.py
@@ -1,6 +1,8 @@
 import random
 import pytest_rerunfailures
 
+import pytest
+
 pytest_plugins = 'pytester'
 
 
@@ -219,3 +221,15 @@ def test_rerun_with_resultslog(testdir):
                                '--result-log', './pytest.log')
 
     assert_outcomes(result, passed=0, failed=1, rerun=2)
+
+
+@pytest.mark.parametrize('delay_time', [0, 0.0, 1, 2.5])
+def test_reruns_with_delay(testdir, delay_time):
+    testdir.makepyfile("""
+        def test_fail():
+            assert False""")
+
+    result = testdir.runpytest('--reruns', '3',
+                               '--reruns-delay', delay_time)
+
+    assert_outcomes(result, passed=0, failed=1, rerun=3)

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py{27,34,35,36,py,py3}-pytest{27,28,29,30,31,32},
+envlist = py{27,34,35,36,py,py3}-pytest{27,28,29,30,31,32,33},
 
 [testenv]
 commands = py.test test_pytest_rerunfailures.py {posargs}
@@ -15,3 +15,4 @@ deps =
     pytest30: pytest==3.0.*
     pytest31: pytest==3.1.*
     pytest32: pytest==3.2.*
+    pytest33: pytest==3.3.*

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ envlist = py{27,34,35,36,py,py3}-pytest{27,28,29,30,31,32,33},
 [testenv]
 commands = py.test test_pytest_rerunfailures.py {posargs}
 deps =
+    mock
     pytest27: pytest==2.7.*
     pytest28: pytest==2.8.*
     pytest29: pytest==2.9.*

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,6 @@ envlist = py{27,34,35,36,py,py3}-pytest{27,28,29,30,31,32,33},
 commands = py.test test_pytest_rerunfailures.py {posargs}
 deps =
     mock
-    pytest27: pytest==2.7.*
     pytest28: pytest==2.8.*
     pytest29: pytest==2.9.*
     pytest30: pytest==3.0.*


### PR DESCRIPTION
This PR add the ability to specify a delay time between test reruns. The time can be specified as a command line argument or a with the "flaky" marker. 

Additionally some small maintenance work was. Tests and CI updated to support pytest 3.3.x