### PR TITLE
Use item.get_closest_marker if possible

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,8 +5,10 @@ Changelog
 4.1 (unreleased)
 ================
 
-- Nothing changed yet.
+- Add support for pytest 3.6 by using ``Node.get_closest_marker()`` (Thanks to
+  `@The-Compiler`_ for the PR).
 
+.. _@The-Compiler: https://github.com/The-Compiler
 
 4.0 (2017-12-23)
 ================

--- a/pytest_rerunfailures.py
+++ b/pytest_rerunfailures.py
@@ -71,8 +71,16 @@ def check_options(config):
         config.pluginmanager.register(config._resultlog)
 
 
+def _get_marker(item):
+    try:
+        return item.get_closest_marker("flaky")
+    except AttributeError:
+        # pytest < 3.6
+        return item.get_marker("flaky")
+
+
 def get_reruns_count(item):
-    rerun_marker = item.get_marker("flaky")
+    rerun_marker = _get_marker(item)
     reruns = None
 
     # use the marker as a priority over the global setting.
@@ -93,7 +101,7 @@ def get_reruns_count(item):
 
 
 def get_reruns_delay(item):
-    rerun_marker = item.get_marker("flaky")
+    rerun_marker = _get_marker(item)
 
     if rerun_marker is not None:
         if "reruns_delay" in rerun_marker.kwargs:


### PR DESCRIPTION
This avoids deprecation warnings on the upcoming pytest 3.6 release:
https://docs.pytest.org/en/features/mark.html#marker-revamp-and-iteration