### PR TITLE
The mock is not needed on python3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 9.1 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Drop dependency on ``mock``.
 
 
 9.0 (2020-03-18)

--- a/test_pytest_rerunfailures.py
+++ b/test_pytest_rerunfailures.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import pytest
 import random
 import time

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,6 @@ envlist = py{35,36,37,38,py3}-pytest{50,51,52,53,54},
 [testenv]
 commands = py.test test_pytest_rerunfailures.py {posargs}
 deps =
-    mock
     pytest50: pytest==5.0.*
     pytest51: pytest==5.1.*
     pytest52: pytest==5.2.*


### PR DESCRIPTION
Use the version from unittest directly