### PR TITLE
README: remove incorrect hookwrapper

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -127,6 +127,6 @@ Development
 
   .. code-block:: python
 
-    @hookimpl(tryfirst=True, hookwrapper=True)
+    @hookimpl(tryfirst=True)
     def pytest_runtest_makereport(item, call):
         print(item.execution_count)


### PR DESCRIPTION
A hookwrapper requires a `yield`, but seems unnecessary here, so just remove it.