### PR TITLE
Add --only-rerun flag to add option to rerun specific errors

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changelog
 ----------------
 
 - Drop dependency on ``mock``.
-
+- Add in new flag ``--only-rerun`` to allow for users to rerun only certain errors.
 
 9.0 (2020-03-18)
 ----------------

--- a/README.rst
+++ b/README.rst
@@ -55,6 +55,24 @@ test re-run is launched:
 
    $ pytest --reruns 5 --reruns-delay 1
 
+Re-run all failures matching certain expressions
+------------------------------------------------
+
+To re-run only those failures that match a certain list of expressions, use the
+``--only-rerun`` flag and pass it a regular expression. For example, the following would
+only rerun those errors that match ``AssertionError``:
+
+.. code-block:: bash
+
+   $ pytest --reruns 5 --only-rerun AssertionError
+   
+Passing the flag multiple times accumulates the arguments, so the following would only rerun
+those errors that match ``AssertionError`` or ``ValueError``:
+
+.. code-block:: bash
+
+   $ pytest --reruns 5 --only-rerun AssertionError --only-rerun ValueError
+
 Re-run individual failures
 --------------------------
 

--- a/pytest_rerunfailures.py
+++ b/pytest_rerunfailures.py
@@ -33,11 +33,11 @@ def pytest_addoption(parser):
         "re-run failing tests to eliminate flaky failures")
     group._addoption(
         '--only-rerun',
-        action='store',
+        action='append',
         dest='only_rerun',
         type=str,
         default=None,
-        help='Optional comma separated list. If passed, only rerun errors matching the regexes provided.'
+        help='If passed, only rerun errors matching the regex provided. Pass this flag multiple times to accumulate a list of regexes to match'
     )
     group._addoption(
         '--reruns',
@@ -190,7 +190,7 @@ def _should_hard_fail_on_error(session_config, report):
     if not rerun_errors:
         return False
 
-    for rerun_regex in rerun_errors.split(','):
+    for rerun_regex in rerun_errors:
         if re.search(rerun_regex, report.longrepr.reprcrash.message):
             return False
 

--- a/pytest_rerunfailures.py
+++ b/pytest_rerunfailures.py
@@ -37,7 +37,7 @@ def pytest_addoption(parser):
         dest='only_rerun',
         type=str,
         default=None,
-        help='Optional comma seperated list. If passed, only rerun errors matching the regexes provided.'
+        help='Optional comma separated list. If passed, only rerun errors matching the regexes provided.'
     )
     group._addoption(
         '--reruns',

--- a/pytest_rerunfailures.py
+++ b/pytest_rerunfailures.py
@@ -182,7 +182,7 @@ def _remove_failed_setup_state_from_session(item):
     setup_state.stack = list()
 
 
-def _should_fail_on_error(session_config, report):
+def _should_hard_fail_on_error(session_config, report):
     if report.outcome != 'failed':
         return False
 
@@ -224,7 +224,7 @@ def pytest_runtest_protocol(item, nextitem):
         reports = runtestprotocol(item, nextitem=nextitem, log=False)
 
         for report in reports:  # 3 reports: setup, call, teardown
-            is_terminal_error = _should_fail_on_error(item.session.config, report)
+            is_terminal_error = _should_hard_fail_on_error(item.session.config, report)
             report.rerun = item.execution_count - 1
             xfail = hasattr(report, 'wasxfail')
             if item.execution_count > reruns or not report.failed or xfail or is_terminal_error:

--- a/test_pytest_rerunfailures.py
+++ b/test_pytest_rerunfailures.py
@@ -423,7 +423,7 @@ def test_pytest_runtest_logfinish_is_called(testdir):
             ('def test_only_rerun(): raise AssertionError("ERR")', 'ERR', True),
         ]
 )
-def test_pytest_only_rerun(testdir, file_text, only_rerun_text, should_rerun):
+def test_only_rerun_flag(testdir, file_text, only_rerun_text, should_rerun):
     testdir.makepyfile(file_text)
 
     num_failed = 1

--- a/test_pytest_rerunfailures.py
+++ b/test_pytest_rerunfailures.py
@@ -421,7 +421,7 @@ def test_pytest_runtest_logfinish_is_called(testdir):
             ('def test_only_rerun(): raise AssertionError("ERR")', ['ERR'], True),
             ('def test_only_rerun(): raise AssertionError("ERR")', ['AssertionError,ValueError'], False),
             ('def test_only_rerun(): raise AssertionError("ERR")', ['AssertionError ValueError'], False),
-            ('def test_only_rerun(): raise AssertionError("ERR")', ['AssertionError','ValueError'], True),
+            ('def test_only_rerun(): raise AssertionError("ERR")', ['AssertionError', 'ValueError'], True),
         ]
 )
 def test_only_rerun_flag(testdir, file_text, only_rerun_texts, should_rerun):

--- a/test_pytest_rerunfailures.py
+++ b/test_pytest_rerunfailures.py
@@ -409,21 +409,22 @@ def test_pytest_runtest_logfinish_is_called(testdir):
     result.stdout.fnmatch_lines(hook_message)
 
 @pytest.mark.parametrize(
-        "file_text, only_rerun_text, should_rerun",
+        "file_text, only_rerun_texts, should_rerun",
         [
-            ('def test_only_rerun(): raise AssertionError("ERR")', 'AssertionError', True),
-            ('def test_only_rerun(): raise AssertionError("ERR")', 'Assertion*', True),
-            ('def test_only_rerun(): raise AssertionError("ERR")', 'Assertion', True),
-            ('def test_only_rerun(): raise AssertionError("ERR")', 'ValueError', False),
-            ('def test_only_rerun(): raise AssertionError("ERR")', 'AssertionError,ValueError', True),
-            ('def test_only_rerun(): raise AssertionError("ERR")', 'AssertionError ValueError', False),
-            ('def test_only_rerun(): raise AssertionError("ERR")', '', True),
-            ('def test_only_rerun(): raise AssertionError("ERR")', 'AssertionError: ', True),
-            ('def test_only_rerun(): raise AssertionError("ERR")', 'AssertionError: ERR', True),
-            ('def test_only_rerun(): raise AssertionError("ERR")', 'ERR', True),
+            ('def test_only_rerun(): raise AssertionError("ERR")', ['AssertionError'], True),
+            ('def test_only_rerun(): raise AssertionError("ERR")', ['Assertion*'], True),
+            ('def test_only_rerun(): raise AssertionError("ERR")', ['Assertion'], True),
+            ('def test_only_rerun(): raise AssertionError("ERR")', ['ValueError'], False),
+            ('def test_only_rerun(): raise AssertionError("ERR")', [''], True),
+            ('def test_only_rerun(): raise AssertionError("ERR")', ['AssertionError: '], True),
+            ('def test_only_rerun(): raise AssertionError("ERR")', ['AssertionError: ERR'], True),
+            ('def test_only_rerun(): raise AssertionError("ERR")', ['ERR'], True),
+            ('def test_only_rerun(): raise AssertionError("ERR")', ['AssertionError,ValueError'], False),
+            ('def test_only_rerun(): raise AssertionError("ERR")', ['AssertionError ValueError'], False),
+            ('def test_only_rerun(): raise AssertionError("ERR")', ['AssertionError','ValueError'], True),
         ]
 )
-def test_only_rerun_flag(testdir, file_text, only_rerun_text, should_rerun):
+def test_only_rerun_flag(testdir, file_text, only_rerun_texts, should_rerun):
     testdir.makepyfile(file_text)
 
     num_failed = 1
@@ -431,5 +432,8 @@ def test_only_rerun_flag(testdir, file_text, only_rerun_text, should_rerun):
     num_reruns = 1
     num_reruns_actual = num_reruns if should_rerun else 0
 
-    result = testdir.runpytest('--reruns', str(num_reruns), '--only-rerun', only_rerun_text)
+    pytest_args = ['--reruns', str(num_reruns)]
+    for only_rerun_text in only_rerun_texts:
+        pytest_args.extend(['--only-rerun', only_rerun_text])
+    result = testdir.runpytest(*pytest_args)
     assert_outcomes(result, passed=num_passed, failed=num_failed, rerun=num_reruns_actual)


### PR DESCRIPTION
Add new flag `--only-rerun` to allow for users to only rerun errors matching regexes passed to this flag. If the flag is omitted or passed in without a value then no changes occur and all failures are rerun.

Closes https://github.com/pytest-dev/pytest-rerunfailures/issues/101