### PR TITLE
refactor the assert_outcomes method to present better messages on assertion failures

### DIFF
--- a/test_pytest_rerunfailures.py
+++ b/test_pytest_rerunfailures.py
@@ -18,6 +18,13 @@ def temporary_failure(count=1):
         count)
 
 
+def check_outcome_field(outcomes, field_name, expected_value):
+    field_value = outcomes.get(field_name, 0)
+    assert field_value == expected_value, \
+            "outcomes.{} has unexpected value. Expected '{}' but got '{}'" \
+            .format(field_name, expected_value, field_value)
+
+
 def assert_outcomes(result, passed=1, skipped=0, failed=0, error=0, xfailed=0,
                     xpassed=0, rerun=0):
     outcomes = result.parseoutcomes()
@@ -27,11 +34,6 @@ def assert_outcomes(result, passed=1, skipped=0, failed=0, error=0, xfailed=0,
     check_outcome_field(outcomes, 'xfailed', xfailed)
     check_outcome_field(outcomes, 'xpassed', xpassed)
     check_outcome_field(outcomes, 'rerun', rerun)
-
-
-def check_outcome_field(outcomes, field_name, expected_value):
-    field_value = outcomes.get(field_name, 0)
-    assert field_value == expected_value, "outcomes.{} has unexpected value. Expected '{}' but got '{}'".format(field_name, expected_value, field_value)
 
 
 def test_error_when_run_with_pdb(testdir):

--- a/test_pytest_rerunfailures.py
+++ b/test_pytest_rerunfailures.py
@@ -21,12 +21,17 @@ def temporary_failure(count=1):
 def assert_outcomes(result, passed=1, skipped=0, failed=0, error=0, xfailed=0,
                     xpassed=0, rerun=0):
     outcomes = result.parseoutcomes()
-    assert outcomes.get('passed', 0) == passed
-    assert outcomes.get('skipped', 0) == skipped
-    assert outcomes.get('failed', 0) == failed
-    assert outcomes.get('xfailed', 0) == xfailed
-    assert outcomes.get('xpassed', 0) == xpassed
-    assert outcomes.get('rerun', 0) == rerun
+    check_outcome_field(outcomes, 'passed', passed)
+    check_outcome_field(outcomes, 'skipped', skipped)
+    check_outcome_field(outcomes, 'failed', failed)
+    check_outcome_field(outcomes, 'xfailed', xfailed)
+    check_outcome_field(outcomes, 'xpassed', xpassed)
+    check_outcome_field(outcomes, 'rerun', rerun)
+
+
+def check_outcome_field(outcomes, field_name, expected_value):
+    field_value = outcomes.get(field_name, 0)
+    assert field_value == expected_value, "outcomes.{} has unexpected value. Expected '{}' but got '{}'".format(field_name, expected_value, field_value)
 
 
 def test_error_when_run_with_pdb(testdir):


### PR DESCRIPTION
Currently, an assertion failure in `assert_outcomes` doesn't say much about what's failing. For example, here is what a failure in a non parametrized and parametrized test look like:

```
FAILED test_pytest_rerunfailures.py::test_rerun_report - AssertionError: assert 0 == 99
FAILED test_pytest_rerunfailures.py::test_only_rerun_flag[def test_only_rerun(): raise AssertionError("ERR")-only_rerun_texts0-True] - AssertionError: assert 0 == 99
```

As you can see, the above doesn't tell us what field is incorrect on the `outcomes` object.

With this change, the same failure would look like this:
```
FAILED test_pytest_rerunfailures.py::test_no_rerun_on_pass - AssertionError: outcomes.failed has unexpected value. Expected '99' but got '0'
FAILED test_pytest_rerunfailures.py::test_only_rerun_flag[def test_only_rerun(): raise AssertionError("ERR")-only_rerun_texts0-True] - AssertionError: outcomes.failed has unexpected value. Expected '99' but got '0'
```

The above shows the same error, but with the field that differed included in error message.