### PR TITLE
Check for warnings output during unit tests

### DIFF
--- a/test_pytest_rerunfailures.py
+++ b/test_pytest_rerunfailures.py
@@ -21,7 +21,7 @@ def temporary_failure(count=1):
 
 
 def assert_outcomes(result, passed=1, skipped=0, failed=0, error=0, xfailed=0,
-                    xpassed=0, rerun=0, warnings=0):
+                    xpassed=0, rerun=0):
     outcomes = result.parseoutcomes()
     assert outcomes.get('passed', 0) == passed
     assert outcomes.get('skipped', 0) == skipped
@@ -29,12 +29,6 @@ def assert_outcomes(result, passed=1, skipped=0, failed=0, error=0, xfailed=0,
     assert outcomes.get('xfailed', 0) == xfailed
     assert outcomes.get('xpassed', 0) == xpassed
     assert outcomes.get('rerun', 0) == rerun
-
-    warnings_key = 'warnings'
-    if warnings <= 1 and pytest_version_gte_53:
-        # due to https://github.com/pytest-dev/pytest/pull/5990
-        warnings_key = 'warning'
-    assert outcomes.get(warnings_key, 0) == warnings
 
 
 def test_error_when_run_with_pdb(testdir):
@@ -252,7 +246,7 @@ def test_reruns_with_delay(testdir, delay_time):
 
     time.sleep.assert_called_with(delay_time)
 
-    assert_outcomes(result, passed=0, failed=1, rerun=3, warnings=num_warnings)
+    assert_outcomes(result, passed=0, failed=1, rerun=3)
 
     if num_warnings:
         result.stdout.fnmatch_lines('*UserWarning: Delay time between re-runs cannot be < 0. Using default value: 0')
@@ -277,7 +271,7 @@ def test_reruns_with_delay_marker(testdir, delay_time):
 
     time.sleep.assert_called_with(delay_time)
 
-    assert_outcomes(result, passed=0, failed=1, rerun=2, warnings=num_warnings)
+    assert_outcomes(result, passed=0, failed=1, rerun=2)
 
     if num_warnings:
         result.stdout.fnmatch_lines('*UserWarning: Delay time between re-runs cannot be < 0. Using default value: 0')

--- a/test_pytest_rerunfailures.py
+++ b/test_pytest_rerunfailures.py
@@ -6,7 +6,6 @@ import time
 
 
 pytest_plugins = 'pytester'
-pytest_version_gte_53 = pkg_resources.parse_version(pytest.__version__) >= pkg_resources.parse_version('5.3')
 
 
 def temporary_failure(count=1):

--- a/test_pytest_rerunfailures.py
+++ b/test_pytest_rerunfailures.py
@@ -239,10 +239,8 @@ def test_reruns_with_delay(testdir, delay_time):
 
     if delay_time < 0:
         result.stdout.fnmatch_lines(
-                '*UserWarning: Delay time between re-runs cannot be < 0. '
-                'Using default value: 0')
-
-    if delay_time < 0:
+            '*UserWarning: Delay time between re-runs cannot be < 0. '
+            'Using default value: 0')
         delay_time = 0
 
     time.sleep.assert_called_with(delay_time)
@@ -265,10 +263,8 @@ def test_reruns_with_delay_marker(testdir, delay_time):
 
     if delay_time < 0:
         result.stdout.fnmatch_lines(
-                '*UserWarning: Delay time between re-runs cannot be < 0. '
-                'Using default value: 0')
-
-    if delay_time < 0:
+            '*UserWarning: Delay time between re-runs cannot be < 0. '
+            'Using default value: 0')
         delay_time = 0
 
     time.sleep.assert_called_with(delay_time)

--- a/test_pytest_rerunfailures.py
+++ b/test_pytest_rerunfailures.py
@@ -1,5 +1,4 @@
 from unittest import mock
-import pkg_resources
 import pytest
 import random
 import time

--- a/test_pytest_rerunfailures.py
+++ b/test_pytest_rerunfailures.py
@@ -238,17 +238,18 @@ def test_reruns_with_delay(testdir, delay_time):
     result = testdir.runpytest('--reruns', '3',
                                '--reruns-delay', str(delay_time))
 
-    num_warnings = 0
+    if delay_time < 0:
+        result.stdout.fnmatch_lines(
+                '*UserWarning: Delay time between re-runs cannot be < 0. '
+                'Using default value: 0')
+
     if delay_time < 0:
         delay_time = 0
-        num_warnings = 1
 
     time.sleep.assert_called_with(delay_time)
 
     assert_outcomes(result, passed=0, failed=1, rerun=3)
 
-    if num_warnings:
-        result.stdout.fnmatch_lines('*UserWarning: Delay time between re-runs cannot be < 0. Using default value: 0')
 
 @pytest.mark.parametrize('delay_time', [-1, 0, 0.0, 1, 2.5])
 def test_reruns_with_delay_marker(testdir, delay_time):
@@ -263,17 +264,18 @@ def test_reruns_with_delay_marker(testdir, delay_time):
 
     result = testdir.runpytest()
 
-    num_warnings = 0
+    if delay_time < 0:
+        result.stdout.fnmatch_lines(
+                '*UserWarning: Delay time between re-runs cannot be < 0. '
+                'Using default value: 0')
+
     if delay_time < 0:
         delay_time = 0
-        num_warnings = 1
 
     time.sleep.assert_called_with(delay_time)
 
     assert_outcomes(result, passed=0, failed=1, rerun=2)
 
-    if num_warnings:
-        result.stdout.fnmatch_lines('*UserWarning: Delay time between re-runs cannot be < 0. Using default value: 0')
 
 def test_rerun_on_setup_class_with_error_with_reruns(testdir):
     """


### PR DESCRIPTION
In the tests, check to make sure that:
- The correct warnings are reported
- The warnings text is correct

Before, we weren't checking but I think we should be since we are setting these warnings in this plugin, and they are not coming from pytest.

No change log as this is trivial