### PR TITLE
Add in pre-commit to repo

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,45 @@
+repos:
+    - repo: https://github.com/psf/black
+      rev: 19.10b0
+      hooks:
+          - id: black
+            args: [--safe, --quiet]
+    - repo: https://github.com/pre-commit/pre-commit-hooks
+      rev: v3.1.0
+      hooks:
+         - id: trailing-whitespace
+         - id: end-of-file-fixer
+         - id: fix-encoding-pragma
+           args: [--remove]
+         - id: check-yaml
+         - id: debug-statements
+           laneuage_version: python3
+      exclude: _pytest/(debugging|hookspec).py
+    - repo: https://gitlab.com/pycqa/flake8
+      rev: 3.8.3
+      hooks:
+         - id: flake8
+           language_version: python3
+           additional_dependencies: [flake8-typing-imports==1.9.0]
+    - repo: https://github.com/asottile/reorder_python_imports
+      rev: v2.3.1
+      hooks:
+         - id: reorder-python-imports
+           args: ['--application-directories=.:src', --py3-plus]
+    - repo: https://github.com/asottile/pyupgrade
+      rev: v2.7.1
+      hooks:
+         - id: pyupgrade
+           args: [--py3-plus]
+    - repo: https://github.com/asottile/setup-cfg-fmt
+      rev: v1.10.0
+      hooks:
+         - id: setup-cfg-fmt
+	- repo: local
+      hooks:
+      	 - id: rst
+           name: rst
+           entry: rst-lint --encoding utf-8
+           files: ^(CHANGES.rst|README.rst)$
+           language: python
+           additional_dependencies: [pygments, restructuredtext_lint]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,8 +13,7 @@ repos:
            args: [--remove]
          - id: check-yaml
          - id: debug-statements
-           laneuage_version: python3
-      exclude: _pytest/(debugging|hookspec).py
+           language_version: python3
     - repo: https://gitlab.com/pycqa/flake8
       rev: 3.8.3
       hooks:
@@ -22,7 +21,7 @@ repos:
            language_version: python3
            additional_dependencies: [flake8-typing-imports==1.9.0]
     - repo: https://github.com/asottile/reorder_python_imports
-      rev: v2.3.1
+      rev: v2.3.0
       hooks:
          - id: reorder-python-imports
            args: ['--application-directories=.:src', --py3-plus]
@@ -31,13 +30,9 @@ repos:
       hooks:
          - id: pyupgrade
            args: [--py3-plus]
-    - repo: https://github.com/asottile/setup-cfg-fmt
-      rev: v1.10.0
+    - repo: local
       hooks:
-         - id: setup-cfg-fmt
-	- repo: local
-      hooks:
-      	 - id: rst
+         - id: rst
            name: rst
            entry: rst-lint --encoding utf-8
            files: ^(CHANGES.rst|README.rst)$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
            language_version: python3
            additional_dependencies: [flake8-typing-imports==1.9.0]
     - repo: https://github.com/asottile/reorder_python_imports
-      rev: v2.3.0
+      rev: v2.3.2
       hooks:
          - id: reorder-python-imports
            args: ['--application-directories=.:src', --py3-plus]

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,5 @@ install:
   - pip install -q pre-commit
   - pre-commit install
 script:
-  - if [[ "$TRAVIS_PYTHON_VERSION" > "3.5" ]]; then pre-commit run --all-files --show-diff-on-failure; fi
+  - if [[ "$TRAVIS_PYTHON_VERSION" > "3.5" ]] && [[ "$TRAVIS_PYTHON_VERSION" != pypy* ]]; then pre-commit run --all-files --show-diff-on-failure; fi
   - py.test

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,5 @@ install:
   - pip install -q pre-commit
   - pre-commit install
 script:
-  - if [ $TRAVIS_PYTHON_VERSION -ge 3.6 ]; pre-commit run --all-files --show-diff-on-failure; fi
+  - if [[ "$TRAVIS_PYTHON_VERSION" > "3.5" ]]; then pre-commit run --all-files --show-diff-on-failure; fi
   - py.test

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,8 @@ env:
 install:
   - pip install -q pytest==$PYTEST
   - pip install -q -e .
-script: py.test
+  - pip install -q pre-commit
+  - pre-commit install
+script:
+  - pre-commit run --all-files --show-diff-on-failure
+  - py.test

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,5 @@ install:
   - pip install -q pre-commit
   - pre-commit install
 script:
-  - pre-commit run --all-files --show-diff-on-failure
+  - if [ $TRAVIS_PYTHON_VERSION -ge 3.6 ]; pre-commit run --all-files --show-diff-on-failure; fi
   - py.test

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,15 @@ Changelog
 ----------------
 
 - Drop dependency on ``mock``.
+
 - Add in new flag ``--only-rerun`` to allow for users to rerun only certain errors.
+
+- Add support for pre-commit and add a linting tox target.
+  (`#117 <https://github.com/pytest-dev/pytest-rerunfailures/pull/117>`_)
+  (PR from `@gnikonorov`_)
+
+.. _@gnikonorov: https://github.com/gnikonorov
+
 
 9.0 (2020-03-18)
 ----------------

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -22,6 +22,8 @@ Preparing Pull Requests
 
    Afterwards ``pre-commit`` will run whenever you commit.
 
+   Note that this is automatically done when running ``tox -e linting``.
+
    https://pre-commit.com/ is a framework for managing and maintaining multi-language pre-commit hooks
    to ensure code-style and code formatting is consistent.
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,0 +1,39 @@
+============================
+Contribution getting started
+============================
+
+Contributions are highly welcomed and appreciated. Every little bit of help counts,
+so do not hesitate!
+
+.. contents::
+   :depth: 2
+   :backlinks: none
+
+
+Preparing Pull Requests
+-----------------------
+
+#. Fork the repository.
+
+#. Enable and install `pre-commit <https://pre-commit.com>`_ to ensure style-guides and code checks are followed::
+
+   $ pip install --user pre-commit
+   $ pre-commit install
+
+   Afterwards ``pre-commit`` will run whenever you commit.
+
+   https://pre-commit.com/ is a framework for managing and maintaining multi-language pre-commit hooks
+   to ensure code-style and code formatting is consistent.
+
+#. Install `tox <https://tox.readthedocs.io/en/latest/>`_::
+
+   Tox is used to run all the tests and will automatically setup virtualenvs
+   to run the tests in.
+   (will implicitly use http://www.virtualenv.org/en/latest/)::
+
+    $ pip install tox
+    $ tox -e linting,py37
+
+#. Follow **PEP-8** for naming and `black <https://github.com/psf/black>`_ for formatting.
+
+#. Add a line item to the current **unreleased** verrsion in ``CHANGES.rst``, unless the change is trivial.

--- a/README.rst
+++ b/README.rst
@@ -65,7 +65,7 @@ only rerun those errors that match ``AssertionError``:
 .. code-block:: bash
 
    $ pytest --reruns 5 --only-rerun AssertionError
-   
+
 Passing the flag multiple times accumulates the arguments, so the following would only rerun
 those errors that match ``AssertionError`` or ``ValueError``:
 

--- a/pytest_rerunfailures.py
+++ b/pytest_rerunfailures.py
@@ -1,14 +1,16 @@
-import pkg_resources
 import re
 import time
 import warnings
 
+import pkg_resources
 import pytest
-
-from _pytest.runner import runtestprotocol
 from _pytest.resultlog import ResultLog
+from _pytest.runner import runtestprotocol
 
-PYTEST_GTE_54 = pkg_resources.parse_version(pytest.__version__) >= pkg_resources.parse_version("5.4")
+PYTEST_GTE_54 = pkg_resources.parse_version(
+    pytest.__version__
+) >= pkg_resources.parse_version("5.4")
+
 
 def works_with_current_xdist():
     """Returns compatibility with installed pytest-xdist version.
@@ -20,8 +22,8 @@ def works_with_current_xdist():
 
     """
     try:
-        d = pkg_resources.get_distribution('pytest-xdist')
-        return d.parsed_version >= pkg_resources.parse_version('1.20')
+        d = pkg_resources.get_distribution("pytest-xdist")
+        return d.parsed_version >= pkg_resources.parse_version("1.20")
     except pkg_resources.DistributionNotFound:
         return None
 
@@ -29,54 +31,61 @@ def works_with_current_xdist():
 # command line options
 def pytest_addoption(parser):
     group = parser.getgroup(
-        "rerunfailures",
-        "re-run failing tests to eliminate flaky failures")
-    group._addoption(
-        '--only-rerun',
-        action='append',
-        dest='only_rerun',
-        type=str,
-        default=None,
-        help='If passed, only rerun errors matching the regex provided. Pass this flag multiple times to accumulate a list of regexes to match'
+        "rerunfailures", "re-run failing tests to eliminate flaky failures"
     )
     group._addoption(
-        '--reruns',
+        "--only-rerun",
+        action="append",
+        dest="only_rerun",
+        type=str,
+        default=None,
+        help="If passed, only rerun errors matching the regex provided. "
+        "Pass this flag multiple times to accumulate a list of regexes "
+        "to match",
+    )
+    group._addoption(
+        "--reruns",
         action="store",
         dest="reruns",
         type=int,
         default=0,
-        help="number of times to re-run failed tests. defaults to 0.")
+        help="number of times to re-run failed tests. defaults to 0.",
+    )
     group._addoption(
-        '--reruns-delay',
-        action='store',
-        dest='reruns_delay',
+        "--reruns-delay",
+        action="store",
+        dest="reruns_delay",
         type=float,
         default=0,
-        help='add time (seconds) delay between reruns.'
+        help="add time (seconds) delay between reruns.",
     )
 
 
 def pytest_configure(config):
     # add flaky marker
     config.addinivalue_line(
-        "markers", "flaky(reruns=1, reruns_delay=0): mark test to re-run up "
-                   "to 'reruns' times. Add a delay of 'reruns_delay' seconds "
-                   "between re-runs.")
+        "markers",
+        "flaky(reruns=1, reruns_delay=0): mark test to re-run up "
+        "to 'reruns' times. Add a delay of 'reruns_delay' seconds "
+        "between re-runs.",
+    )
 
 
 def _get_resultlog(config):
     if PYTEST_GTE_54:
         # hack
         from _pytest.resultlog import resultlog_key
+
         return config._store.get(resultlog_key, default=None)
     else:
-        return getattr(config, '_resultlog', None)
+        return getattr(config, "_resultlog", None)
 
 
 def _set_resultlog(config, resultlog):
     if PYTEST_GTE_54:
         # hack
         from _pytest.resultlog import resultlog_key
+
         config._store[resultlog_key] = resultlog
     else:
         config._resultlog = resultlog
@@ -88,9 +97,8 @@ def check_options(config):
     val = config.getvalue
     if not val("collectonly"):
         if config.option.reruns != 0:
-            if config.option.usepdb:   # a core option
+            if config.option.usepdb:  # a core option
                 raise pytest.UsageError("--reruns incompatible with --pdb")
-
 
     resultlog = _get_resultlog(config)
     if resultlog:
@@ -146,8 +154,9 @@ def get_reruns_delay(item):
 
     if delay < 0:
         delay = 0
-        warnings.warn('Delay time between re-runs cannot be < 0. '
-                      'Using default value: 0')
+        warnings.warn(
+            "Delay time between re-runs cannot be < 0. " "Using default value: 0"
+        )
 
     return delay
 
@@ -156,9 +165,9 @@ def _remove_cached_results_from_failed_fixtures(item):
     """
     Note: remove all cached_result attribute from every fixture
     """
-    cached_result = 'cached_result'
-    fixture_info = getattr(item, '_fixtureinfo', None)
-    for fixture_def_str in getattr(fixture_info, 'name2fixturedefs', ()):
+    cached_result = "cached_result"
+    fixture_info = getattr(item, "_fixtureinfo", None)
+    for fixture_def_str in getattr(fixture_info, "name2fixturedefs", ()):
         fixture_defs = fixture_info.name2fixturedefs[fixture_def_str]
         for fixture_def in fixture_defs:
             if getattr(fixture_def, cached_result, None) is not None:
@@ -172,10 +181,11 @@ def _remove_cached_results_from_failed_fixtures(item):
 
 def _remove_failed_setup_state_from_session(item):
     """
-    Note: remove all _prepare_exc attribute from every col in stack of _setupstate and cleaning the stack itself
+    Note: remove all _prepare_exc attribute from every col in stack of
+          _setupstate and cleaning the stack itself
     """
     prepare_exc = "_prepare_exc"
-    setup_state = getattr(item.session, '_setupstate')
+    setup_state = getattr(item.session, "_setupstate")
     for col in setup_state.stack:
         if hasattr(col, prepare_exc):
             delattr(col, prepare_exc)
@@ -183,7 +193,7 @@ def _remove_failed_setup_state_from_session(item):
 
 
 def _should_hard_fail_on_error(session_config, report):
-    if report.outcome != 'failed':
+    if report.outcome != "failed":
         return False
 
     rerun_errors = session_config.option.only_rerun
@@ -213,26 +223,30 @@ def pytest_runtest_protocol(item, nextitem):
     # first item if necessary
     check_options(item.session.config)
     delay = get_reruns_delay(item)
-    parallel = hasattr(item.config, 'slaveinput')
+    parallel = hasattr(item.config, "slaveinput")
     item.execution_count = 0
 
     need_to_run = True
     while need_to_run:
         item.execution_count += 1
-        item.ihook.pytest_runtest_logstart(nodeid=item.nodeid,
-                                           location=item.location)
+        item.ihook.pytest_runtest_logstart(nodeid=item.nodeid, location=item.location)
         reports = runtestprotocol(item, nextitem=nextitem, log=False)
 
         for report in reports:  # 3 reports: setup, call, teardown
             is_terminal_error = _should_hard_fail_on_error(item.session.config, report)
             report.rerun = item.execution_count - 1
-            xfail = hasattr(report, 'wasxfail')
-            if item.execution_count > reruns or not report.failed or xfail or is_terminal_error:
+            xfail = hasattr(report, "wasxfail")
+            if (
+                item.execution_count > reruns
+                or not report.failed
+                or xfail
+                or is_terminal_error
+            ):
                 # last run or no failure detected, log normally
                 item.ihook.pytest_runtest_logreport(report=report)
             else:
                 # failure detected and reruns not exhausted, since i < reruns
-                report.outcome = 'rerun'
+                report.outcome = "rerun"
                 time.sleep(delay)
 
                 if not parallel or works_with_current_xdist():
@@ -247,8 +261,7 @@ def pytest_runtest_protocol(item, nextitem):
         else:
             need_to_run = False
 
-        item.ihook.pytest_runtest_logfinish(nodeid=item.nodeid,
-                                            location=item.location)
+        item.ihook.pytest_runtest_logfinish(nodeid=item.nodeid, location=item.location)
 
     return True
 
@@ -256,8 +269,8 @@ def pytest_runtest_protocol(item, nextitem):
 def pytest_report_teststatus(report):
     """Adapted from https://pytest.org/latest/_modules/_pytest/skipping.html
     """
-    if report.outcome == 'rerun':
-        return 'rerun', 'R', ('RERUN', {'yellow': True})
+    if report.outcome == "rerun":
+        return "rerun", "R", ("RERUN", {"yellow": True})
 
 
 def pytest_terminal_summary(terminalreporter):
@@ -269,7 +282,7 @@ def pytest_terminal_summary(terminalreporter):
 
     lines = []
     for char in tr.reportchars:
-        if char in 'rR':
+        if char in "rR":
             show_rerun(terminalreporter, lines)
 
     if lines:
@@ -283,7 +296,7 @@ def show_rerun(terminalreporter, lines):
     if rerun:
         for rep in rerun:
             pos = rep.nodeid
-            lines.append("RERUN %s" % (pos,))
+            lines.append("RERUN {}".format(pos))
 
 
 class RerunResultLog(ResultLog):
@@ -299,17 +312,17 @@ class RerunResultLog(ResultLog):
             return
         res = self.config.hook.pytest_report_teststatus(report=report)
         code = res[1]
-        if code == 'x':
+        if code == "x":
             longrepr = str(report.longrepr)
-        elif code == 'X':
-            longrepr = ''
+        elif code == "X":
+            longrepr = ""
         elif report.passed:
             longrepr = ""
         elif report.failed:
             longrepr = str(report.longrepr)
         elif report.skipped:
             longrepr = str(report.longrepr[2])
-        elif report.outcome == 'rerun':
+        elif report.outcome == "rerun":
             longrepr = str(report.longrepr)
         else:
             longrepr = str(report.longrepr)

--- a/pytest_rerunfailures.py
+++ b/pytest_rerunfailures.py
@@ -155,7 +155,7 @@ def get_reruns_delay(item):
     if delay < 0:
         delay = 0
         warnings.warn(
-            "Delay time between re-runs cannot be < 0. " "Using default value: 0"
+            "Delay time between re-runs cannot be < 0. Using default value: 0"
         )
 
     return delay

--- a/setup.py
+++ b/setup.py
@@ -1,44 +1,39 @@
 from setuptools import setup
 
-with open('README.rst') as readme, open('CHANGES.rst') as changelog:
-    long_description = (
-        '.. contents::\n\n' +
-        readme.read() +
-        '\n\n' +
-        changelog.read())
+with open("README.rst") as readme, open("CHANGES.rst") as changelog:
+    long_description = ".. contents::\n\n" + readme.read() + "\n\n" + changelog.read()
 
-setup(name='pytest-rerunfailures',
-      version='9.1.dev0',
-      description='pytest plugin to re-run tests to eliminate flaky failures',
-      long_description=long_description,
-      author='Leah Klearman',
-      author_email='lklrmn@gmail.com',
-      url='https://github.com/pytest-dev/pytest-rerunfailures',
-      py_modules=['pytest_rerunfailures'],
-      entry_points={'pytest11': ['rerunfailures = pytest_rerunfailures']},
-      install_requires=[
-          'setuptools>=40.0',
-          'pytest >= 5.0',
-      ],
-      python_requires='>=3.5',
-      license='Mozilla Public License 2.0 (MPL 2.0)',
-      keywords='py.test pytest rerun failures flaky',
-      zip_safe=False,
-      classifiers=[
-          'Development Status :: 5 - Production/Stable',
-          'Framework :: Pytest',
-          'Intended Audience :: Developers',
-          'License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)',
-          'Operating System :: POSIX',
-          'Operating System :: Microsoft :: Windows',
-          'Operating System :: MacOS :: MacOS X',
-          'Topic :: Software Development :: Quality Assurance',
-          'Topic :: Software Development :: Testing',
-          'Topic :: Utilities',
-          'Programming Language :: Python :: 3.5',
-          'Programming Language :: Python :: 3.6',
-          'Programming Language :: Python :: 3.7',
-          'Programming Language :: Python :: 3.8',
-          'Programming Language :: Python :: Implementation :: CPython',
-          'Programming Language :: Python :: Implementation :: PyPy',
-      ])
+setup(
+    name="pytest-rerunfailures",
+    version="9.1.dev0",
+    description="pytest plugin to re-run tests to eliminate flaky failures",
+    long_description=long_description,
+    author="Leah Klearman",
+    author_email="lklrmn@gmail.com",
+    url="https://github.com/pytest-dev/pytest-rerunfailures",
+    py_modules=["pytest_rerunfailures"],
+    entry_points={"pytest11": ["rerunfailures = pytest_rerunfailures"]},
+    install_requires=["setuptools>=40.0", "pytest >= 5.0"],
+    python_requires=">=3.5",
+    license="Mozilla Public License 2.0 (MPL 2.0)",
+    keywords="py.test pytest rerun failures flaky",
+    zip_safe=False,
+    classifiers=[
+        "Development Status :: 5 - Production/Stable",
+        "Framework :: Pytest",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)",
+        "Operating System :: POSIX",
+        "Operating System :: Microsoft :: Windows",
+        "Operating System :: MacOS :: MacOS X",
+        "Topic :: Software Development :: Quality Assurance",
+        "Topic :: Software Development :: Testing",
+        "Topic :: Utilities",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: Implementation :: CPython",
+        "Programming Language :: Python :: Implementation :: PyPy",
+    ],
+)

--- a/test_pytest_rerunfailures.py
+++ b/test_pytest_rerunfailures.py
@@ -1,10 +1,11 @@
-from unittest import mock
-import pytest
 import random
 import time
+from unittest import mock
+
+import pytest
 
 
-pytest_plugins = 'pytester'
+pytest_plugins = "pytester"
 
 
 def temporary_failure(count=1):
@@ -15,239 +16,297 @@ def temporary_failure(count=1):
             if int(count) <= {0}:
                 path.write(int(count) + 1)
                 raise Exception('Failure: {{0}}'.format(count))""".format(
-        count)
+        count
+    )
 
 
 def check_outcome_field(outcomes, field_name, expected_value):
     field_value = outcomes.get(field_name, 0)
-    assert field_value == expected_value, \
-            "outcomes.{} has unexpected value. Expected '{}' but got '{}'" \
-            .format(field_name, expected_value, field_value)
+    assert (
+        field_value == expected_value
+    ), "outcomes.{} has unexpected value. Expected '{}' but got '{}'".format(
+        field_name, expected_value, field_value
+    )
 
 
-def assert_outcomes(result, passed=1, skipped=0, failed=0, error=0, xfailed=0,
-                    xpassed=0, rerun=0):
+def assert_outcomes(
+    result, passed=1, skipped=0, failed=0, error=0, xfailed=0, xpassed=0, rerun=0,
+):
     outcomes = result.parseoutcomes()
-    check_outcome_field(outcomes, 'passed', passed)
-    check_outcome_field(outcomes, 'skipped', skipped)
-    check_outcome_field(outcomes, 'failed', failed)
-    check_outcome_field(outcomes, 'xfailed', xfailed)
-    check_outcome_field(outcomes, 'xpassed', xpassed)
-    check_outcome_field(outcomes, 'rerun', rerun)
+    check_outcome_field(outcomes, "passed", passed)
+    check_outcome_field(outcomes, "skipped", skipped)
+    check_outcome_field(outcomes, "failed", failed)
+    check_outcome_field(outcomes, "xfailed", xfailed)
+    check_outcome_field(outcomes, "xpassed", xpassed)
+    check_outcome_field(outcomes, "rerun", rerun)
 
 
 def test_error_when_run_with_pdb(testdir):
-    testdir.makepyfile('def test_pass(): pass')
-    result = testdir.runpytest('--reruns', '1', '--pdb')
-    result.stderr.fnmatch_lines_random(
-        'ERROR: --reruns incompatible with --pdb')
+    testdir.makepyfile("def test_pass(): pass")
+    result = testdir.runpytest("--reruns", "1", "--pdb")
+    result.stderr.fnmatch_lines_random("ERROR: --reruns incompatible with --pdb")
 
 
 def test_no_rerun_on_pass(testdir):
-    testdir.makepyfile('def test_pass(): pass')
-    result = testdir.runpytest('--reruns', '1')
+    testdir.makepyfile("def test_pass(): pass")
+    result = testdir.runpytest("--reruns", "1")
     assert_outcomes(result)
 
 
 def test_no_rerun_on_skipif_mark(testdir):
     reason = str(random.random())
-    testdir.makepyfile("""
+    testdir.makepyfile(
+        """
         import pytest
-        @pytest.mark.skipif(reason='{0}')
+        @pytest.mark.skipif(reason='{}')
         def test_skip():
             pass
-    """.format(reason))
-    result = testdir.runpytest('--reruns', '1')
+    """.format(
+            reason
+        )
+    )
+    result = testdir.runpytest("--reruns", "1")
     assert_outcomes(result, passed=0, skipped=1)
 
 
 def test_no_rerun_on_skip_call(testdir):
     reason = str(random.random())
-    testdir.makepyfile("""
+    testdir.makepyfile(
+        """
         import pytest
         def test_skip():
-            pytest.skip('{0}')
-    """.format(reason))
-    result = testdir.runpytest('--reruns', '1')
+            pytest.skip('{}')
+    """.format(
+            reason
+        )
+    )
+    result = testdir.runpytest("--reruns", "1")
     assert_outcomes(result, passed=0, skipped=1)
 
 
 def test_no_rerun_on_xfail_mark(testdir):
-    reason = str(random.random())
-    testdir.makepyfile("""
+    testdir.makepyfile(
+        """
         import pytest
         @pytest.mark.xfail()
         def test_xfail():
             assert False
-    """.format(reason))
-    result = testdir.runpytest('--reruns', '1')
+    """
+    )
+    result = testdir.runpytest("--reruns", "1")
     assert_outcomes(result, passed=0, xfailed=1)
 
 
 def test_no_rerun_on_xfail_call(testdir):
     reason = str(random.random())
-    testdir.makepyfile("""
+    testdir.makepyfile(
+        """
         import pytest
         def test_xfail():
-            pytest.xfail('{0}')
-    """.format(reason))
-    result = testdir.runpytest('--reruns', '1')
+            pytest.xfail('{}')
+    """.format(
+            reason
+        )
+    )
+    result = testdir.runpytest("--reruns", "1")
     assert_outcomes(result, passed=0, xfailed=1)
 
 
 def test_no_rerun_on_xpass(testdir):
-    reason = str(random.random())
-    testdir.makepyfile("""
+    testdir.makepyfile(
+        """
         import pytest
         @pytest.mark.xfail()
         def test_xpass():
             pass
-    """.format(reason))
-    result = testdir.runpytest('--reruns', '1')
+    """
+    )
+    result = testdir.runpytest("--reruns", "1")
     assert_outcomes(result, passed=0, xpassed=1)
 
 
 def test_rerun_fails_after_consistent_setup_failure(testdir):
-    testdir.makepyfile('def test_pass(): pass')
-    testdir.makeconftest("""
+    testdir.makepyfile("def test_pass(): pass")
+    testdir.makeconftest(
+        """
         def pytest_runtest_setup(item):
-            raise Exception('Setup failure')""")
-    result = testdir.runpytest('--reruns', '1')
+            raise Exception('Setup failure')"""
+    )
+    result = testdir.runpytest("--reruns", "1")
     assert_outcomes(result, passed=0, error=1, rerun=1)
 
 
 def test_rerun_passes_after_temporary_setup_failure(testdir):
-    testdir.makepyfile('def test_pass(): pass')
-    testdir.makeconftest("""
+    testdir.makepyfile("def test_pass(): pass")
+    testdir.makeconftest(
+        """
         def pytest_runtest_setup(item):
-            {0}""".format(temporary_failure()))
-    result = testdir.runpytest('--reruns', '1', '-r', 'R')
+            {}""".format(
+            temporary_failure()
+        )
+    )
+    result = testdir.runpytest("--reruns", "1", "-r", "R")
     assert_outcomes(result, passed=1, rerun=1)
 
 
 def test_rerun_fails_after_consistent_test_failure(testdir):
-    testdir.makepyfile('def test_fail(): assert False')
-    result = testdir.runpytest('--reruns', '1')
+    testdir.makepyfile("def test_fail(): assert False")
+    result = testdir.runpytest("--reruns", "1")
     assert_outcomes(result, passed=0, failed=1, rerun=1)
 
 
 def test_rerun_passes_after_temporary_test_failure(testdir):
-    testdir.makepyfile("""
+    testdir.makepyfile(
+        """
         def test_pass():
-            {0}""".format(temporary_failure()))
-    result = testdir.runpytest('--reruns', '1', '-r', 'R')
+            {}""".format(
+            temporary_failure()
+        )
+    )
+    result = testdir.runpytest("--reruns", "1", "-r", "R")
     assert_outcomes(result, passed=1, rerun=1)
 
 
 def test_rerun_passes_after_temporary_test_failure_with_flaky_mark(testdir):
-    testdir.makepyfile("""
+    testdir.makepyfile(
+        """
         import pytest
         @pytest.mark.flaky(reruns=2)
         def test_pass():
-            {0}""".format(temporary_failure(2)))
-    result = testdir.runpytest('-r', 'R')
+            {}""".format(
+            temporary_failure(2)
+        )
+    )
+    result = testdir.runpytest("-r", "R")
     assert_outcomes(result, passed=1, rerun=2)
 
 
 def test_reruns_if_flaky_mark_is_called_without_options(testdir):
-    testdir.makepyfile("""
+    testdir.makepyfile(
+        """
         import pytest
         @pytest.mark.flaky()
         def test_pass():
-            {0}""".format(temporary_failure(1)))
-    result = testdir.runpytest('-r', 'R')
+            {}""".format(
+            temporary_failure(1)
+        )
+    )
+    result = testdir.runpytest("-r", "R")
     assert_outcomes(result, passed=1, rerun=1)
 
 
 def test_reruns_if_flaky_mark_is_called_with_positional_argument(testdir):
-    testdir.makepyfile("""
+    testdir.makepyfile(
+        """
         import pytest
         @pytest.mark.flaky(2)
         def test_pass():
-            {0}""".format(temporary_failure(2)))
-    result = testdir.runpytest('-r', 'R')
+            {}""".format(
+            temporary_failure(2)
+        )
+    )
+    result = testdir.runpytest("-r", "R")
     assert_outcomes(result, passed=1, rerun=2)
 
 
 def test_no_extra_test_summary_for_reruns_by_default(testdir):
-    testdir.makepyfile("""
+    testdir.makepyfile(
+        """
         def test_pass():
-            {0}""".format(temporary_failure()))
-    result = testdir.runpytest('--reruns', '1')
-    assert 'RERUN' not in result.stdout.str()
-    assert '1 rerun' in result.stdout.str()
+            {}""".format(
+            temporary_failure()
+        )
+    )
+    result = testdir.runpytest("--reruns", "1")
+    assert "RERUN" not in result.stdout.str()
+    assert "1 rerun" in result.stdout.str()
 
 
 def test_extra_test_summary_for_reruns(testdir):
-    testdir.makepyfile("""
+    testdir.makepyfile(
+        """
         def test_pass():
-            {0}""".format(temporary_failure()))
-    result = testdir.runpytest('--reruns', '1', '-r', 'R')
-    result.stdout.fnmatch_lines_random(['RERUN test_*:*'])
-    assert '1 rerun' in result.stdout.str()
+            {}""".format(
+            temporary_failure()
+        )
+    )
+    result = testdir.runpytest("--reruns", "1", "-r", "R")
+    result.stdout.fnmatch_lines_random(["RERUN test_*:*"])
+    assert "1 rerun" in result.stdout.str()
 
 
 def test_verbose(testdir):
-    testdir.makepyfile("""
+    testdir.makepyfile(
+        """
         def test_pass():
-            {0}""".format(temporary_failure()))
-    result = testdir.runpytest('--reruns', '1', '-v')
-    result.stdout.fnmatch_lines_random(['test_*:* RERUN*'])
-    assert '1 rerun' in result.stdout.str()
+            {}""".format(
+            temporary_failure()
+        )
+    )
+    result = testdir.runpytest("--reruns", "1", "-v")
+    result.stdout.fnmatch_lines_random(["test_*:* RERUN*"])
+    assert "1 rerun" in result.stdout.str()
 
 
 def test_no_rerun_on_class_setup_error_without_reruns(testdir):
-    testdir.makepyfile("""
+    testdir.makepyfile(
+        """
         class TestFoo(object):
             @classmethod
             def setup_class(cls):
                 assert False
 
             def test_pass():
-                pass""")
-    result = testdir.runpytest('--reruns', '0')
+                pass"""
+    )
+    result = testdir.runpytest("--reruns", "0")
     assert_outcomes(result, passed=0, error=1, rerun=0)
 
 
 def test_rerun_on_class_setup_error_with_reruns(testdir):
-    testdir.makepyfile("""
+    testdir.makepyfile(
+        """
         class TestFoo(object):
             @classmethod
             def setup_class(cls):
                 assert False
 
             def test_pass():
-                pass""")
-    result = testdir.runpytest('--reruns', '1')
+                pass"""
+    )
+    result = testdir.runpytest("--reruns", "1")
     assert_outcomes(result, passed=0, error=1, rerun=1)
 
 
 def test_rerun_with_resultslog(testdir):
-    testdir.makepyfile("""
+    testdir.makepyfile(
+        """
         def test_fail():
-            assert False""")
+            assert False"""
+    )
 
-    result = testdir.runpytest('--reruns', '2',
-                               '--result-log', './pytest.log')
+    result = testdir.runpytest("--reruns", "2", "--result-log", "./pytest.log")
 
     assert_outcomes(result, passed=0, failed=1, rerun=2)
 
 
-@pytest.mark.parametrize('delay_time', [-1, 0, 0.0, 1, 2.5])
+@pytest.mark.parametrize("delay_time", [-1, 0, 0.0, 1, 2.5])
 def test_reruns_with_delay(testdir, delay_time):
-    testdir.makepyfile("""
+    testdir.makepyfile(
+        """
         def test_fail():
-            assert False""")
+            assert False"""
+    )
 
     time.sleep = mock.MagicMock()
 
-    result = testdir.runpytest('--reruns', '3',
-                               '--reruns-delay', str(delay_time))
+    result = testdir.runpytest("--reruns", "3", "--reruns-delay", str(delay_time))
 
     if delay_time < 0:
         result.stdout.fnmatch_lines(
-            '*UserWarning: Delay time between re-runs cannot be < 0. '
-            'Using default value: 0')
+            "*UserWarning: Delay time between re-runs cannot be < 0. "
+            "Using default value: 0"
+        )
         delay_time = 0
 
     time.sleep.assert_called_with(delay_time)
@@ -255,14 +314,18 @@ def test_reruns_with_delay(testdir, delay_time):
     assert_outcomes(result, passed=0, failed=1, rerun=3)
 
 
-@pytest.mark.parametrize('delay_time', [-1, 0, 0.0, 1, 2.5])
+@pytest.mark.parametrize("delay_time", [-1, 0, 0.0, 1, 2.5])
 def test_reruns_with_delay_marker(testdir, delay_time):
-    testdir.makepyfile("""
+    testdir.makepyfile(
+        """
         import pytest
 
         @pytest.mark.flaky(reruns=2, reruns_delay={})
         def test_fail_two():
-            assert False""".format(delay_time))
+            assert False""".format(
+            delay_time
+        )
+    )
 
     time.sleep = mock.MagicMock()
 
@@ -270,8 +333,9 @@ def test_reruns_with_delay_marker(testdir, delay_time):
 
     if delay_time < 0:
         result.stdout.fnmatch_lines(
-            '*UserWarning: Delay time between re-runs cannot be < 0. '
-            'Using default value: 0')
+            "*UserWarning: Delay time between re-runs cannot be < 0. "
+            "Using default value: 0"
+        )
         delay_time = 0
 
     time.sleep.assert_called_with(delay_time)
@@ -283,7 +347,8 @@ def test_rerun_on_setup_class_with_error_with_reruns(testdir):
     """
      Case: setup_class throwing error on the first execution for parametrized test
     """
-    testdir.makepyfile("""
+    testdir.makepyfile(
+        """
         import pytest
 
         pass_fixture = False
@@ -298,16 +363,19 @@ def test_rerun_on_setup_class_with_error_with_reruns(testdir):
                 assert True
             @pytest.mark.parametrize('param', [1, 2, 3])
             def test_pass(self, param):
-                assert param""")
-    result = testdir.runpytest('--reruns', '1')
+                assert param"""
+    )
+    result = testdir.runpytest("--reruns", "1")
     assert_outcomes(result, passed=3, rerun=1)
 
 
 def test_rerun_on_class_scope_fixture_with_error_with_reruns(testdir):
     """
-    Case: Class scope fixture throwing error on the first execution for parametrized test
+    Case: Class scope fixture throwing error on the first execution
+    for parametrized test
     """
-    testdir.makepyfile("""
+    testdir.makepyfile(
+        """
         import pytest
 
         pass_fixture = False
@@ -323,17 +391,19 @@ def test_rerun_on_class_scope_fixture_with_error_with_reruns(testdir):
                 assert True
             @pytest.mark.parametrize('param', [1, 2, 3])
             def test_pass(self, setup_fixture, param):
-                assert param""")
-    result = testdir.runpytest('--reruns', '1')
+                assert param"""
+    )
+    result = testdir.runpytest("--reruns", "1")
     assert_outcomes(result, passed=3, rerun=1)
 
 
 def test_rerun_on_module_fixture_with_reruns(testdir):
     """
-    Case: Module scope fixture is not re-executed when class scope fixture throwing error on the first execution
-    for parametrized test
+    Case: Module scope fixture is not re-executed when class scope fixture throwing
+    error on the first execution for parametrized test
     """
-    testdir.makepyfile("""
+    testdir.makepyfile(
+        """
         import pytest
 
         pass_fixture = False
@@ -354,17 +424,19 @@ def test_rerun_on_module_fixture_with_reruns(testdir):
                 assert True
 
             def test_pass_2(self, module_fixture, setup_fixture):
-                assert True""")
-    result = testdir.runpytest('--reruns', '1')
+                assert True"""
+    )
+    result = testdir.runpytest("--reruns", "1")
     assert_outcomes(result, passed=2, rerun=1)
 
 
 def test_rerun_on_session_fixture_with_reruns(testdir):
     """
-    Case: Module scope fixture is not re-executed when class scope fixture throwing error on the first execution
-    for parametrized test
+    Case: Module scope fixture is not re-executed when class scope fixture
+    throwing error on the first execution for parametrized test
     """
-    testdir.makepyfile("""
+    testdir.makepyfile(
+        """
         import pytest
 
         pass_fixture = False
@@ -385,57 +457,91 @@ def test_rerun_on_session_fixture_with_reruns(testdir):
             def test_pass_1(self, session_fixture, setup_fixture):
                 assert True
             def test_pass_2(self, session_fixture, setup_fixture):
-                assert True""")
-    result = testdir.runpytest('--reruns', '1')
+                assert True"""
+    )
+    result = testdir.runpytest("--reruns", "1")
     assert_outcomes(result, passed=2, rerun=1)
 
 
 def test_execution_count_exposed(testdir):
-    testdir.makepyfile('def test_pass(): assert True')
-    testdir.makeconftest("""
+    testdir.makepyfile("def test_pass(): assert True")
+    testdir.makeconftest(
+        """
         def pytest_runtest_teardown(item):
-            assert item.execution_count == 3""")
-    result = testdir.runpytest('--reruns', '2')
+            assert item.execution_count == 3"""
+    )
+    result = testdir.runpytest("--reruns", "2")
     assert_outcomes(result, passed=3, rerun=2)
 
 
 def test_rerun_report(testdir):
-    testdir.makepyfile('def test_pass(): assert False')
-    testdir.makeconftest("""
+    testdir.makepyfile("def test_pass(): assert False")
+    testdir.makeconftest(
+        """
         def pytest_runtest_logreport(report):
             assert hasattr(report, 'rerun')
             assert isinstance(report.rerun, int)
             assert report.rerun <= 2
-        """)
-    result = testdir.runpytest('--reruns', '2')
+        """
+    )
+    result = testdir.runpytest("--reruns", "2")
     assert_outcomes(result, failed=1, rerun=2, passed=0)
 
 
 def test_pytest_runtest_logfinish_is_called(testdir):
     hook_message = "Message from pytest_runtest_logfinish hook"
-    testdir.makepyfile('def test_pass(): pass')
-    testdir.makeconftest(r"""
+    testdir.makepyfile("def test_pass(): pass")
+    testdir.makeconftest(
+        r"""
         def pytest_runtest_logfinish(nodeid, location):
-            print("\n{0}\n")
-    """.format(hook_message))
-    result = testdir.runpytest('--reruns', '1', '-s')
+            print("\n{}\n")
+    """.format(
+            hook_message
+        )
+    )
+    result = testdir.runpytest("--reruns", "1", "-s")
     result.stdout.fnmatch_lines(hook_message)
 
+
 @pytest.mark.parametrize(
-        "file_text, only_rerun_texts, should_rerun",
-        [
-            ('def test_only_rerun(): raise AssertionError("ERR")', ['AssertionError'], True),
-            ('def test_only_rerun(): raise AssertionError("ERR")', ['Assertion*'], True),
-            ('def test_only_rerun(): raise AssertionError("ERR")', ['Assertion'], True),
-            ('def test_only_rerun(): raise AssertionError("ERR")', ['ValueError'], False),
-            ('def test_only_rerun(): raise AssertionError("ERR")', [''], True),
-            ('def test_only_rerun(): raise AssertionError("ERR")', ['AssertionError: '], True),
-            ('def test_only_rerun(): raise AssertionError("ERR")', ['AssertionError: ERR'], True),
-            ('def test_only_rerun(): raise AssertionError("ERR")', ['ERR'], True),
-            ('def test_only_rerun(): raise AssertionError("ERR")', ['AssertionError,ValueError'], False),
-            ('def test_only_rerun(): raise AssertionError("ERR")', ['AssertionError ValueError'], False),
-            ('def test_only_rerun(): raise AssertionError("ERR")', ['AssertionError', 'ValueError'], True),
-        ]
+    "file_text, only_rerun_texts, should_rerun",
+    [
+        (
+            'def test_only_rerun(): raise AssertionError("ERR")',
+            ["AssertionError"],
+            True,
+        ),
+        ('def test_only_rerun(): raise AssertionError("ERR")', ["Assertion*"], True,),
+        ('def test_only_rerun(): raise AssertionError("ERR")', ["Assertion"], True,),
+        ('def test_only_rerun(): raise AssertionError("ERR")', ["ValueError"], False,),
+        ('def test_only_rerun(): raise AssertionError("ERR")', [""], True),
+        (
+            'def test_only_rerun(): raise AssertionError("ERR")',
+            ["AssertionError: "],
+            True,
+        ),
+        (
+            'def test_only_rerun(): raise AssertionError("ERR")',
+            ["AssertionError: ERR"],
+            True,
+        ),
+        ('def test_only_rerun(): raise AssertionError("ERR")', ["ERR"], True),
+        (
+            'def test_only_rerun(): raise AssertionError("ERR")',
+            ["AssertionError,ValueError"],
+            False,
+        ),
+        (
+            'def test_only_rerun(): raise AssertionError("ERR")',
+            ["AssertionError ValueError"],
+            False,
+        ),
+        (
+            'def test_only_rerun(): raise AssertionError("ERR")',
+            ["AssertionError", "ValueError"],
+            True,
+        ),
+    ],
 )
 def test_only_rerun_flag(testdir, file_text, only_rerun_texts, should_rerun):
     testdir.makepyfile(file_text)
@@ -445,8 +551,10 @@ def test_only_rerun_flag(testdir, file_text, only_rerun_texts, should_rerun):
     num_reruns = 1
     num_reruns_actual = num_reruns if should_rerun else 0
 
-    pytest_args = ['--reruns', str(num_reruns)]
+    pytest_args = ["--reruns", str(num_reruns)]
     for only_rerun_text in only_rerun_texts:
-        pytest_args.extend(['--only-rerun', only_rerun_text])
+        pytest_args.extend(["--only-rerun", only_rerun_text])
     result = testdir.runpytest(*pytest_args)
-    assert_outcomes(result, passed=num_passed, failed=num_failed, rerun=num_reruns_actual)
+    assert_outcomes(
+        result, passed=num_passed, failed=num_failed, rerun=num_reruns_actual
+    )

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,12 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py{35,36,37,38,py3}-pytest{50,51,52,53,54},
+distshare = {homedir}/.tox/distshare
+envlist =
+    linting
+    py{35,36,37,38,py3}-pytest{50,51,52,53,54}
+isolated_build = True
+minversion = 3.5.3
 
 [testenv]
 commands = py.test test_pytest_rerunfailures.py {posargs}
@@ -14,3 +19,10 @@ deps =
     pytest52: pytest==5.2.*
     pytest53: pytest==5.3.*
     pytest54: pytest==5.4.*
+
+# potentially can add install_command ( see https://tox.readthedocs.io/en/latest/config.html?highlight=skip_install#conf-skip_install )
+[testenv:linting]
+basepython = python3
+commands = pre-commit run --all-files --show-diff-on-failure {posargs:}
+deps = pre-commit>=1.11.0
+skip_install = True

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,6 @@
 max-line-length = 88
 
 [tox]
-distshare = {homedir}/.tox/distshare
 envlist =
     linting
     py{35,36,37,38,py3}-pytest{50,51,52,53,54}
@@ -27,8 +26,5 @@ deps =
 [testenv:linting]
 basepython = python3
 commands = pre-commit run --all-files --show-diff-on-failure {posargs:}
-commands_pre =
-    pip install pre-commit
-    pre-commit install
 deps = pre-commit>=1.11.0
 skip_install = True

--- a/tox.ini
+++ b/tox.ini
@@ -3,13 +3,17 @@
 # test suite on all supported python versions. To use it, "pip install tox"
 # and then run "tox" from this directory.
 
+[flake8]
+# NOTE: This is kept in line with Black
+#       See: https://black.readthedocs.io/en/stable/the_black_code_style.html#line-length
+max-line-length = 88
+
 [tox]
 distshare = {homedir}/.tox/distshare
 envlist =
     linting
     py{35,36,37,38,py3}-pytest{50,51,52,53,54}
-isolated_build = True
-minversion = 3.5.3
+minversion = 3.17.1
 
 [testenv]
 commands = py.test test_pytest_rerunfailures.py {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -24,9 +24,11 @@ deps =
     pytest53: pytest==5.3.*
     pytest54: pytest==5.4.*
 
-# potentially can add install_command ( see https://tox.readthedocs.io/en/latest/config.html?highlight=skip_install#conf-skip_install )
 [testenv:linting]
 basepython = python3
 commands = pre-commit run --all-files --show-diff-on-failure {posargs:}
+commands_pre =
+    pip install pre-commit
+    pre-commit install
 deps = pre-commit>=1.11.0
 skip_install = True


### PR DESCRIPTION
This PR adds pre-commit to this plugin and makes it as similar to `pytest`'s  [pre-commit-config](https://github.com/pytest-dev/pytest/blob/master/.pre-commit-config.yaml) as possible. This is intentional to make it easier for developers to switch between projects, and IMO the pytest pre-commit setup is quite nice.

This PR also adds a linting target ( `tox -e linting` ) to this repo for ease of use and applies it to all existing code.

Also, pre commit is run on PR's in the Travis pipeline. This is intentionally redundant, since it is possible for a user to bypass precommit locally and without this CI check we don't have a guaranteed way of enforcing pre-commit. We would still greatly benefit from pre-commit developer side as it gives the user immediate feedback if they are not trying to skip it, and greatly speeds up their development time and cuts down on code review for all involved, since style is already guaranteed to be correct.

The most notable precommit linting addition is [black](https://github.com/psf/black) to enforce code style, and keeps the line length close to @sallner's preferred 80 at 88. See the justification for why [here](https://black.readthedocs.io/en/stable/the_black_code_style.html#line-length).

There are a few outstanding issues that I would like to tackle in follow up PRs, which I will raise once this PR is approved and/or merged. Most notably:
- Support `isolated_build=true` in the tox file ( see [this link](https://tox.readthedocs.io/en/latest/config.html#conf-isolated_build) ). It is deferred since it requires creating a `pyproject.toml` file.
- Add `setup-cfg-fmt` to the pre  commit config like we do in [pytest](https://github.com/pytest-dev/pytest/blob/master/.pre-commit-config.yaml#L39). This requires work on our setup.cfg file, though, and should be deferred since it's beyond scope, and needs consensus IMO before proceeding  
- https://github.com/pytest-dev/pytest-rerunfailures/pull/117#discussion_r462251913

**NOTE**: I did not test the travis config file changes, as I do not know how to. The rest is tested and confirmed working.

Closes https://github.com/pytest-dev/pytest-rerunfailures/issues/114
Closes https://github.com/pytest-dev/pytest-rerunfailures/issues/80