### PR TITLE
Ensure all test reports are processed regardless of prior report status

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,10 @@ Changelog
   (`#117 <https://github.com/pytest-dev/pytest-rerunfailures/pull/117>`_)
   (PR from `@gnikonorov`_)
 
+- Ensure ``pytest_runtest_logreport`` is called for all reports in a test.
+  (`#108 <https://github.com/pytest-dev/pytest-rerunfailures/issues/108>`_)
+  (PR from `@gnikonorov`_)
+
 .. _@gnikonorov: https://github.com/gnikonorov
 
 

--- a/pytest_rerunfailures.py
+++ b/pytest_rerunfailures.py
@@ -246,7 +246,7 @@ def pytest_runtest_protocol(item, nextitem):
                 or need_to_rerun
             ):
                 # out of rerun attempts, no errors detected, or we're finishing off
-                # the reports of a filed test log normally
+                # the reports of a failed test, log normally
                 item.ihook.pytest_runtest_logreport(report=report)
             else:
                 # failure detected and reruns not exhausted, since i < reruns
@@ -258,7 +258,8 @@ def pytest_runtest_protocol(item, nextitem):
                     item.ihook.pytest_runtest_logreport(report=report)
 
         if need_to_rerun:
-            # at least one report failed and we have reruns rerun the test
+            # at least one report failed and we have reruns left
+            # prepare to rerun the test
             time.sleep(delay)
 
             # cleanin item's cashed results from any level of setups


### PR DESCRIPTION
Ensure that we always process all reports for a test in `pytest_runtest_protocol` regardless of whether a past report for a test failed. We now defer any pre-rerun setup until after all reports are executed while still keeping the same rerun logic.

Fixes https://github.com/pytest-dev/pytest-rerunfailures/issues/108