### PR TITLE
Reduce pytest requirement to 4.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     url="https://github.com/pytest-dev/pytest-rerunfailures",
     py_modules=["pytest_rerunfailures"],
     entry_points={"pytest11": ["rerunfailures = pytest_rerunfailures"]},
-    install_requires=["setuptools>=40.0", "pytest >= 5.0"],
+    install_requires=["setuptools>=40.0", "pytest >= 4.4"],
     python_requires=">=3.5",
     license="Mozilla Public License 2.0 (MPL 2.0)",
     keywords="py.test pytest rerun failures flaky",


### PR DESCRIPTION
The code and tests still work with pytest 4.4

Fixes: commit 43e8c38abe2efb52a03b93a5ea078946fca2a41f