### PR TITLE
work around ResultLog support for pytest>=6.1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,7 +7,7 @@ Changelog
 Other changes
 +++++++++++++
 
-- Deprecated `--result-log` was removed in pytest 6.1.0.
+- Deprecate ``--result-log``, as it was removed in pytest 6.1.0
 
 
 9.1 (2020-08-26)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,10 @@ Changelog
 9.2 (unreleased)
 ----------------
 
-- Nothing changed yet.
+Other changes
++++++++++++++
+
+- Deprecated `--result-log` was removed in pytest 6.1.0.
 
 
 9.1 (2020-08-26)

--- a/test_pytest_rerunfailures.py
+++ b/test_pytest_rerunfailures.py
@@ -2,10 +2,15 @@ import random
 import time
 from unittest import mock
 
+import pkg_resources
 import pytest
 
 
 pytest_plugins = "pytester"
+
+PYTEST_GTE_61 = pkg_resources.parse_version(
+    pytest.__version__
+) >= pkg_resources.parse_version("6.1")
 
 
 def temporary_failure(count=1):
@@ -278,23 +283,17 @@ def test_rerun_on_class_setup_error_with_reruns(testdir):
     assert_outcomes(result, passed=0, error=1, rerun=1)
 
 
+@pytest.mark.skipif(PYTEST_GTE_61, reason="--result-log removed in pytest>=6.1")
 def test_rerun_with_resultslog(testdir):
-    import pkg_resources
-
-    PYTEST_LT_61 = pkg_resources.parse_version(
-        pytest.__version__
-    ) < pkg_resources.parse_version("6.1")
-
     testdir.makepyfile(
         """
         def test_fail():
             assert False"""
     )
 
-    if PYTEST_LT_61:
-        result = testdir.runpytest("--reruns", "2", "--result-log", "./pytest.log")
+    result = testdir.runpytest("--reruns", "2", "--result-log", "./pytest.log")
 
-        assert_outcomes(result, passed=0, failed=1, rerun=2)
+    assert_outcomes(result, passed=0, failed=1, rerun=2)
 
 
 @pytest.mark.parametrize("delay_time", [-1, 0, 0.0, 1, 2.5])

--- a/test_pytest_rerunfailures.py
+++ b/test_pytest_rerunfailures.py
@@ -279,15 +279,22 @@ def test_rerun_on_class_setup_error_with_reruns(testdir):
 
 
 def test_rerun_with_resultslog(testdir):
+    import pkg_resources
+
+    PYTEST_LT_61 = pkg_resources.parse_version(
+        pytest.__version__
+    ) < pkg_resources.parse_version("6.1")
+
     testdir.makepyfile(
         """
         def test_fail():
             assert False"""
     )
 
-    result = testdir.runpytest("--reruns", "2", "--result-log", "./pytest.log")
+    if PYTEST_LT_61:
+        result = testdir.runpytest("--reruns", "2", "--result-log", "./pytest.log")
 
-    assert_outcomes(result, passed=0, failed=1, rerun=2)
+        assert_outcomes(result, passed=0, failed=1, rerun=2)
 
 
 @pytest.mark.parametrize("delay_time", [-1, 0, 0.0, 1, 2.5])


### PR DESCRIPTION
This is a workaround that closes #128. It does not address potential integration with the reportlog plugin.