### PR TITLE
Remove implication of literal block in Tox installation section

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -27,7 +27,7 @@ Preparing Pull Requests
    https://pre-commit.com/ is a framework for managing and maintaining multi-language pre-commit hooks
    to ensure code-style and code formatting is consistent.
 
-#. Install `tox <https://tox.readthedocs.io/en/latest/>`_::
+#. Install `tox <https://tox.readthedocs.io/en/latest/>`_:
 
    Tox is used to run all the tests and will automatically setup virtualenvs
    to run the tests in. Implicitly http://www.virtualenv.org/en/latest/ is used::


### PR DESCRIPTION
Suggested-by: rst-lint:
WARNING ./CONTRIBUTING.rst:32 Literal block expected; none found.

Suggested-by: doc8
CONTRIBUTING.rst:32: D000 Literal block expected; none found.