### PR TITLE
Fix document starts, indentation and line length in YAML files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+---
 repos:
     - repo: https://github.com/psf/black
       rev: 19.10b0
@@ -7,34 +8,34 @@ repos:
     - repo: https://github.com/pre-commit/pre-commit-hooks
       rev: v3.1.0
       hooks:
-         - id: trailing-whitespace
-         - id: end-of-file-fixer
-         - id: fix-encoding-pragma
-           args: [--remove]
-         - id: check-yaml
-         - id: debug-statements
-           language_version: python3
+          - id: trailing-whitespace
+          - id: end-of-file-fixer
+          - id: fix-encoding-pragma
+            args: [--remove]
+          - id: check-yaml
+          - id: debug-statements
+            language_version: python3
     - repo: https://gitlab.com/pycqa/flake8
       rev: 3.8.3
       hooks:
-         - id: flake8
-           language_version: python3
-           additional_dependencies: [flake8-typing-imports==1.9.0]
+          - id: flake8
+            language_version: python3
+            additional_dependencies: [flake8-typing-imports==1.9.0]
     - repo: https://github.com/asottile/reorder_python_imports
       rev: v2.3.2
       hooks:
-         - id: reorder-python-imports
-           args: ['--application-directories=.:src', --py3-plus]
+          - id: reorder-python-imports
+            args: ['--application-directories=.:src', --py3-plus]
     - repo: https://github.com/asottile/pyupgrade
       rev: v2.7.1
       hooks:
-         - id: pyupgrade
-           args: [--py3-plus]
+          - id: pyupgrade
+            args: [--py3-plus]
     - repo: local
       hooks:
-         - id: rst
-           name: rst
-           entry: rst-lint --encoding utf-8
-           files: ^(CHANGES.rst|README.rst)$
-           language: python
-           additional_dependencies: [pygments, restructuredtext_lint]
+          - id: rst
+            name: rst
+            entry: rst-lint --encoding utf-8
+            files: ^(CHANGES.rst|README.rst)$
+            language: python
+            additional_dependencies: [pygments, restructuredtext_lint]

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+---
 language: python
 python:
   - 3.5
@@ -17,5 +18,8 @@ install:
   - pip install -q pre-commit
   - pre-commit install
 script:
-  - if [[ "$TRAVIS_PYTHON_VERSION" > "3.5" ]] && [[ "$TRAVIS_PYTHON_VERSION" != pypy* ]]; then pre-commit run --all-files --show-diff-on-failure; fi
+  - if [[ "$TRAVIS_PYTHON_VERSION" > "3.5"  ]] &&
+       [[ "$TRAVIS_PYTHON_VERSION" != pypy* ]]; then
+      pre-commit run --all-files --show-diff-on-failure;
+    fi
   - py.test


### PR DESCRIPTION
Suggested-by: yamllint
./.pre-commit-config.yaml
  1:1       warning  missing document start "---"  (document-start)
  10:10     error    wrong indentation: expected 10 but found 9  (indentation)
  20:10     error    wrong indentation: expected 10 but found 9  (indentation)
  26:10     error    wrong indentation: expected 10 but found 9  (indentation)
  31:10     error    wrong indentation: expected 10 but found 9  (indentation)
  35:10     error    wrong indentation: expected 10 but found 9  (indentation)

./.travis.yml
  1:1       warning  missing document start "---"  (document-start)
  20:81     error    line too long (148 > 80 characters)  (line-length)