### PR TITLE
Test two newest pytest minor versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,9 @@ env:
   - PYTEST=5.4.1
   - PYTEST=6.0.2
   - PYTEST=6.1.0
+jobs:
+  allow_failures:
+  - env: PYTEST=6.1.0
 install:
   - pip install -q pytest==$PYTEST
   - pip install -q -e .

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ env:
   - PYTEST=5.2.4
   - PYTEST=5.3.5
   - PYTEST=5.4.1
+  - PYTEST=6.0.2
+  - PYTEST=6.1.0
 install:
   - pip install -q pytest==$PYTEST
   - pip install -q -e .

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 9.2 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Add support for pytest version 6.0 and 6.1.
 
 
 9.1 (2020-08-26)

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     url="https://github.com/pytest-dev/pytest-rerunfailures",
     py_modules=["pytest_rerunfailures"],
     entry_points={"pytest11": ["rerunfailures = pytest_rerunfailures"]},
-    install_requires=["setuptools>=40.0", "pytest >= 5.0"],
+    install_requires=["setuptools>=40.0", "pytest >= 5.0, <6.1.0"],
     python_requires=">=3.5",
     license="Mozilla Public License 2.0 (MPL 2.0)",
     keywords="py.test pytest rerun failures flaky",

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ max-line-length = 88
 [tox]
 envlist =
     linting
-    py{35,36,37,38,py3}-pytest{50,51,52,53,54}
+    py{35,36,37,38,py3}-pytest{50,51,52,53,54,60,61}
 minversion = 3.17.1
 
 [testenv]
@@ -22,6 +22,8 @@ deps =
     pytest52: pytest==5.2.*
     pytest53: pytest==5.3.*
     pytest54: pytest==5.4.*
+    pytest60: pytest==6.0.*
+    pytest61: pytest==6.1.*
 
 [testenv:linting]
 basepython = python3


### PR DESCRIPTION
To ensure compatibility with newer versions.

Pytest 6.1.0 currently fails due to https://github.com/pytest-dev/pytest-rerunfailures/issues/128. 

Does this need a CHANGES.rst entry? 