### PR TITLE
Test with current pytest versions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,9 @@ env:
   - PYTEST=5.1.3
   - PYTEST=5.2.4
   - PYTEST=5.3.5
-  - PYTEST=5.4.1
+  - PYTEST=5.4.3
+  - PYTEST=6.0.2
+  - PYTEST=6.1.0
 install:
   - pip install -q pytest==$PYTEST
   - pip install -q -e .

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,8 @@ Other changes
 
 - Deprecate ``--result-log``, as it was removed in pytest 6.1.0
 
+- Support up to pytest 6.1.0.
+
 
 9.1 (2020-08-26)
 ----------------

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ max-line-length = 88
 [tox]
 envlist =
     linting
-    py{35,36,37,38,py3}-pytest{50,51,52,53,54}
+    py{35,36,37,38,py3}-pytest{50,51,52,53,54,60,61}
 minversion = 3.17.1
 
 [testenv]
@@ -22,6 +22,8 @@ deps =
     pytest52: pytest==5.2.*
     pytest53: pytest==5.3.*
     pytest54: pytest==5.4.*
+    pytest60: pytest==6.0.*
+    pytest61: pytest==6.1.*
 
 [testenv:linting]
 basepython = python3


### PR DESCRIPTION
This is an exception to rule of the last 5 minor versions of pytest, as this is just the bug fix and a quick workaround. The other versions will be dropped in next minor version.