### PR TITLE
Test on GitHub Actions to speed up CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,40 @@
+name: Lint
+
+on: [push, pull_request]
+
+env:
+  FORCE_COLOR: 1
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cache/pip
+            ~/.cache/pre-commit
+          key:
+            lint-v1-${{ hashFiles('**/setup.py') }}-${{ hashFiles('**/.pre-commit-config.yaml') }}
+          restore-keys: |
+            lint-v1-
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: Install dependencies
+        run: |
+          python -m pip install -U pip
+          python -m pip install pre-commit
+
+      - name: Lint
+        run: |
+          pre-commit run --all-files --show-diff-on-failure
+        env:
+          PRE_COMMIT_COLOR: always

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,61 @@
+name: Test
+
+on: [push, pull_request]
+
+env:
+  FORCE_COLOR: 1
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [
+            "3.5",
+            "3.6",
+            "3.7",
+            "3.8",
+            "pypy3",
+        ]
+        pytest-version: [
+            "5.0.1",
+            "5.1.3",
+            "5.2.4",
+            "5.3.5",
+            "5.4.3",
+            "6.0.2",
+            "6.1.0",
+        ]
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Get pip cache dir
+        id: pip-cache
+        run: |
+          echo "::set-output name=dir::$(pip cache dir)"
+
+      - name: Cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.pip-cache.outputs.dir }}
+          key:
+            ${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.pytest-version }}-v1-${{ hashFiles('**/setup.py') }}
+          restore-keys: |
+            ${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.pytest-version }}-v1-
+
+      - name: Install dependencies
+        run: |
+          python -m pip install -U pip
+          python -m pip install pytest==${{ matrix.pytest-version }}
+          python -m pip install -e .
+
+      - name: Tests
+        shell: bash
+        run: |
+          pytest


### PR DESCRIPTION
* GitHub Actions provides 20 parallel jobs compared to 5 at Travis CI.

* There's no need to run the (pre-commit) linting on all 35 jobs (5 Python * 7 pytest versions), so include a separate workflow to run it against a single recent Python version

* Add caching of pip and pre-commit

* Also no need to `pre-commit install`, that's only need for `git commit`

* I've not removed `.travis.yml` config yet in case you'd like to confirm GHA running on `master` first (needs a merge)

---

The last `master` build on Travis ran for 12 min 31 sec:

* https://travis-ci.org/github/pytest-dev/pytest-rerunfailures/builds/731184308

This PR, lint ran for 1 min 5 sec, and test for 3 min 24 sec, with a lot of overlap:
* https://github.com/hugovk/pytest-rerunfailures/actions/runs/278443761
* https://github.com/hugovk/pytest-rerunfailures/actions/runs/278443760
