### PR TITLE
Flaky test finder plugin extension - Enhancement PR

### DIFF
--- a/pytest_rerunfailures.py
+++ b/pytest_rerunfailures.py
@@ -187,7 +187,7 @@ def get_reruns_delay(item):
 
 
 def get_flaky_flag(item):
-    if int(item.session.config.option.flaky_test_finder)>1:
+    if int(item.session.config.option.flaky_test_finder) > 1:
        warnings.warn(
            "Suggested values: --flaky-test-find = <0 means disabled, 1 means enabled>."
        )

--- a/pytest_rerunfailures.py
+++ b/pytest_rerunfailures.py
@@ -310,13 +310,15 @@ def pytest_runtest_protocol(item, nextitem):
 
 
 def pytest_report_teststatus(report):
-    """Adapted from https://pytest.org/latest/_modules/_pytest/skipping.html"""
+    """Adapted from https://pytest.org/latest/_modules/_pytest/skipping.html
+    """
     if report.outcome == "rerun":
         return "rerun", "R", ("RERUN", {"yellow": True})
 
 
 def pytest_terminal_summary(terminalreporter, config):
-    """Adapted from https://pytest.org/latest/_modules/_pytest/skipping.html"""
+    """Adapted from https://pytest.org/latest/_modules/_pytest/skipping.html
+    """
     tr = terminalreporter
     if not tr.reportchars:
         return

--- a/pytest_rerunfailures.py
+++ b/pytest_rerunfailures.py
@@ -1,6 +1,7 @@
 import re
 import time
 import warnings
+import constants
 
 import pkg_resources
 import pytest
@@ -21,6 +22,8 @@ PYTEST_GTE_54 = pkg_resources.parse_version(
     pytest.__version__
 ) >= pkg_resources.parse_version("5.4")
 
+listOfFlakyTestCases = []
+constants.is_flaky_flag_set = 0
 
 def works_with_current_xdist():
     """Returns compatibility with installed pytest-xdist version.
@@ -68,6 +71,14 @@ def pytest_addoption(parser):
         type=float,
         default=0,
         help="add time (seconds) delay between reruns.",
+    )
+    group.addoption(
+        '--flaky-test-finder',
+        action='store',
+        dest='flaky_test_finder',
+        type=int,
+        default=0,
+        help='To find Flaky tests i.e. A test that passes after retries!',
     )
 
 
@@ -175,6 +186,12 @@ def get_reruns_delay(item):
     return delay
 
 
+def get_flaky_flag(item):
+    if int(item.session.config.option.flaky_test_finder)>1:
+       warnings.warn("Suggested values: --flaky-test-find = <0 means disabled, 1 means enabled>.")
+    return int(item.session.config.option.flaky_test_finder)
+
+
 def _remove_cached_results_from_failed_fixtures(item):
     """
     Note: remove all cached_result attribute from every fixture
@@ -258,6 +275,11 @@ def pytest_runtest_protocol(item, nextitem):
             ):
                 # last run or no failure detected, log normally
                 item.ihook.pytest_runtest_logreport(report=report)
+                if report.when == "call":
+                    constants.is_flaky_flag_set = get_flaky_flag(item)
+                if item.execution_count != 1 and not report.failed and report.when == "call" and constants.is_flaky_flag_set == 1:
+                    print("\nFLAKY TEST DETECTED: " + str(report.nodeid))
+                    listOfFlakyTestCases.append(str(report.nodeid))
             else:
                 # failure detected and reruns not exhausted, since i < reruns
                 report.outcome = "rerun"
@@ -276,6 +298,9 @@ def pytest_runtest_protocol(item, nextitem):
             need_to_run = False
 
         item.ihook.pytest_runtest_logfinish(nodeid=item.nodeid, location=item.location)
+
+    if nextitem is None and constants.is_flaky_flag_set == 1:
+        print("\nList of Flaky testcases in this run: ", listOfFlakyTestCases)
 
     return True
 
@@ -303,6 +328,9 @@ def pytest_terminal_summary(terminalreporter):
         tr._tw.sep("=", "rerun test summary info")
         for line in lines:
             tr._tw.line(line)
+
+    if constants.is_flaky_flag_set == 1:
+        print("\nList of Flaky testcases in this run: ", listOfFlakyTestCases)
 
 
 def show_rerun(terminalreporter, lines):

--- a/pytest_rerunfailures.py
+++ b/pytest_rerunfailures.py
@@ -188,9 +188,9 @@ def get_reruns_delay(item):
 
 def get_flaky_flag(item):
     if int(item.session.config.option.flaky_test_finder) > 1:
-       warnings.warn(
-           "Suggested values: --flaky-test-find = <0 means disabled, 1 means enabled>."
-       )
+        warnings.warn(
+            "Suggested values: --flaky-test-find = <0 means disabled, 1 means enabled>."
+        )
     return int(item.session.config.option.flaky_test_finder)
 
 

--- a/pytest_rerunfailures.py
+++ b/pytest_rerunfailures.py
@@ -1,8 +1,8 @@
 import re
 import time
 import warnings
-import constants
 
+import constants
 import pkg_resources
 import pytest
 from _pytest.runner import runtestprotocol
@@ -24,6 +24,7 @@ PYTEST_GTE_54 = pkg_resources.parse_version(
 
 listOfFlakyTestCases = []
 constants.is_flaky_flag_set = 0
+
 
 def works_with_current_xdist():
     """Returns compatibility with installed pytest-xdist version.
@@ -73,12 +74,13 @@ def pytest_addoption(parser):
         help="add time (seconds) delay between reruns.",
     )
     group.addoption(
-        '--flaky-test-finder',
-        action='store',
-        dest='flaky_test_finder',
+        "--flaky-test-finder",
+        action="store",
+        dest="flaky_test_finder",
         type=int,
         default=0,
-        help='To find Flaky tests i.e. A test that passes after retries!',
+        help="To find Flaky tests i.e. A test that passes after retries!",
+
     )
 
 
@@ -188,7 +190,9 @@ def get_reruns_delay(item):
 
 def get_flaky_flag(item):
     if int(item.session.config.option.flaky_test_finder)>1:
-       warnings.warn("Suggested values: --flaky-test-find = <0 means disabled, 1 means enabled>.")
+       warnings.warn(
+           "Suggested values: --flaky-test-find = <0 means disabled, 1 means enabled>."
+       )
     return int(item.session.config.option.flaky_test_finder)
 
 
@@ -277,7 +281,12 @@ def pytest_runtest_protocol(item, nextitem):
                 item.ihook.pytest_runtest_logreport(report=report)
                 if report.when == "call":
                     constants.is_flaky_flag_set = get_flaky_flag(item)
-                if item.execution_count != 1 and not report.failed and report.when == "call" and constants.is_flaky_flag_set == 1:
+                if (
+                    item.execution_count != 1
+                    and not report.failed
+                    and report.when == "call"
+                    and constants.is_flaky_flag_set == 1
+                ):
                     print("\nFLAKY TEST DETECTED: " + str(report.nodeid))
                     listOfFlakyTestCases.append(str(report.nodeid))
             else:

--- a/pytest_rerunfailures.py
+++ b/pytest_rerunfailures.py
@@ -78,7 +78,6 @@ def pytest_addoption(parser):
         type=int,
         default=0,
         help="To find Flaky tests i.e. A test that passes after retries!",
-
     )
 
 
@@ -311,15 +310,13 @@ def pytest_runtest_protocol(item, nextitem):
 
 
 def pytest_report_teststatus(report):
-    """Adapted from https://pytest.org/latest/_modules/_pytest/skipping.html
-    """
+    """Adapted from https://pytest.org/latest/_modules/_pytest/skipping.html"""
     if report.outcome == "rerun":
         return "rerun", "R", ("RERUN", {"yellow": True})
 
 
 def pytest_terminal_summary(terminalreporter, config):
-    """Adapted from https://pytest.org/latest/_modules/_pytest/skipping.html
-    """
+    """Adapted from https://pytest.org/latest/_modules/_pytest/skipping.html"""
     tr = terminalreporter
     if not tr.reportchars:
         return


### PR DESCRIPTION
**New plugin extension to find flaky tests:**
	**Flaky test:** A test that passes after retry (or retries).

	`--flaky-test-finder=<0 mean disabled, 1 means enabled>`

This extension identifies the tests that are flaky in nature satisfying the above definition. 
When this extension is not enabled, it maintains the original functionality of rerun-failures plugin without any effects. 

Output:
=====
`pytest -v test_example.py --reruns=3 --flaky-test-finder=1`

<------- trimmed output------->
...................
test_example.py::test_example_1 RERUN                                                                                               [ 16%]
test_example.py::test_example_1 PASSED                                                                                              [ 16%]
FLAKY TEST DETECTED: test_example.py::test_example_1
...................
test_example.py::test_example_5 RERUN                                                                                               [ 83%]
test_example.py::test_example_5 RERUN                                                                                               [ 83%]
test_example.py::test_example_5 PASSED                                                                                              [ 83%]
FLAKY TEST DETECTED: test_example.py::test_example_5
....................
test_example.py::test_example_6 PASSED                                                                                              [100%]
....................
List of Flaky testcases in this run:  ['test_example.py::test_example_1', 'test_example.py::test_example_5']

Contributors:
[Yash Saboo](https://github.com/yashsaboo)
[Nirupam K N](https://github.com/Nirupamkn)