### PR TITLE
Add optional condition to marker

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,9 @@ Other changes
 - Check for the resultlog by feature and not by version as pytest master does
   not provide a consistent version.
 
+- Add ``condition`` keyword argument to the re-run marker. (Thanks to `@BeyondEvil`_ for the PR)
+
+.. _@BeyondEvil: https://github.com/BeyondEvil
 
 9.1.1 (2020-09-29)
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -99,6 +99,17 @@ You can also specify the re-run delay time in the marker:
       import random
       assert random.choice([True, False])
 
+You can also specify an optional ``condition`` in the re-run marker:
+
+.. code-block:: python
+
+   @pytest.mark.flaky(reruns=5, condition=sys.platform.startswith("win32"))
+   def test_example():
+      import random
+      assert random.choice([True, False])
+
+Note that the test will re-run for any ``condition`` that is truthy.
+
 Output
 ------
 


### PR DESCRIPTION
The use case we have in [pytest-html](https://github.com/pytest-dev/pytest-html) is that we have a test that is [flaky](https://github.com/pytest-dev/pytest-html/pull/414) only on Windows, so I'd like that test to re-run on the condition that it is running in a Windows environment.

@gnikonorov 