### PR TITLE
Add support for Python 3.10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
           "main",
         ]
         exclude:
-          # Only pylast 6.2+ supports Python 3.10
+          # Only pytest 6.2+ supports Python 3.10
           - { python-version: "3.10-dev", pytest-version: "5.3.*" }
           - { python-version: "3.10-dev", pytest-version: "5.4.*" }
           - { python-version: "3.10-dev", pytest-version: "6.0.*" }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,12 @@ jobs:
           "6.2.*",
           "main",
         ]
+        exclude:
+          # Only pylast 6.2+ supports Python 3.10
+          - { python-version: "3.10-dev", pytest-version: "5.3.*" }
+          - { python-version: "3.10-dev", pytest-version: "5.4.*" }
+          - { python-version: "3.10-dev", pytest-version: "6.0.*" }
+          - { python-version: "3.10-dev", pytest-version: "6.1.*" }
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,7 @@ jobs:
           "3.7",
           "3.8",
           "3.9",
+          "3.10-dev",
           "pypy3",
         ]
         pytest-version: [

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 10.2 (unreleased)
 -----------------
 
-- Nothing changed yet.
+- Add support for Python 3.10 (as of Python 3.10.rc2).
+  (Thanks to `@hugovk <https://github.com/hugovk>`_ for the PR.)
 
 
 10.1 (2021-07-02)
@@ -34,16 +35,16 @@ Features
 ++++++++
 
 - Add ``condition`` keyword argument to the re-run marker.
-  (Thanks to `@BeyondEvil`_ for the PR)
+  (Thanks to `@BeyondEvil`_ for the PR.)
 
 - Add support for Python 3.9.
-  (Thanks to `@digitronik`_ for the PR)
+  (Thanks to `@digitronik`_ for the PR.)
 
 - Add support for pytest 6.3.
-  (Thanks to `@bluetech`_ for the PR)
+  (Thanks to `@bluetech`_ for the PR.)
 
 - Add compatibility with ``pytest-xdist >= 2.0``.
-  (Thanks to `@bluetech`_ for the PR)
+  (Thanks to `@bluetech`_ for the PR.)
 
 Other changes
 +++++++++++++

--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ Requirements
 
 You will need the following prerequisites in order to use pytest-rerunfailures:
 
-- Python 3.6, up to 3.9, or PyPy3
+- Python 3.6, up to 3.10, or PyPy3
 - pytest 5.3 or newer
 
 This package is currently tested against the last 5 minor pytest releases. In

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,8 @@ max-line-length = 88
 [tox]
 envlist =
     linting
-    py{36,37,38,39,310,py3}-pytest{53,54,60,61,62}
+    py{36,37,38,39,py3}-pytest{53,54,60,61,62,main}
+    py310-pytest{62,main}
 minversion = 3.17.1
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ max-line-length = 88
 [tox]
 envlist =
     linting
-    py{36,37,38,39,py3}-pytest{53,54,60,61,62}
+    py{36,37,38,39,310,py3}-pytest{53,54,60,61,62}
 minversion = 3.17.1
 
 [testenv]


### PR DESCRIPTION
Python 3.10.0 final is due for release in October:

* https://www.python.org/dev/peps/pep-0619/

The final release candidate is now out and the Python release team has issued a call to action for community members:

> We strongly encourage maintainers of third-party Python projects to prepare their projects for 3.10 compatibilities during this phase. As always, report any issues to the Python bug tracker.

https://discuss.python.org/t/python-3-10-0rc2-is-now-available/10496?u=hugovk

So let's also test and add support for 3.10.
