### PR TITLE
Fix crashitem names mismatch between client and server.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changelog
 -----------------
 
 - Fix crashitem names mismatch between client and server.
-  (`#172 https://github.com/pytest-dev/pytest-rerunfailures/issues/172`_)
+  (`#172 <https://github.com/pytest-dev/pytest-rerunfailures/issues/172>`_)
 
 
 10.2 (2021-09-17)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 10.3 (unreleased)
 -----------------
 
-- Nothing changed yet.
+- Fix crashitem names mismatch between client and server.
+  (`#172 https://github.com/pytest-dev/pytest-rerunfailures/issues/172`_)
 
 
 10.2 (2021-09-17)

--- a/pytest_rerunfailures.py
+++ b/pytest_rerunfailures.py
@@ -482,10 +482,9 @@ def pytest_runtest_protocol(item, nextitem):
     check_options(item.session.config)
     delay = get_reruns_delay(item)
     parallel = not is_master(item.config)
-    item_location = (item.location[0] + "::" + item.location[2]).replace("\\", "/")
     db = item.session.config.failures_db
-    item.execution_count = db.get_test_failures(item_location)
-    db.set_test_reruns(item_location, reruns)
+    item.execution_count = db.get_test_failures(item.nodeid)
+    db.set_test_reruns(item.nodeid, reruns)
 
     if item.execution_count > reruns:
         return True


### PR DESCRIPTION
Fixes #172.

The identifier used for the failures/reruns DB is inconsistent, on the client side it is built as:

https://github.com/pytest-dev/pytest-rerunfailures/blob/02c2df72fcd6a0d320538a55c6b0cec510ee3289/pytest_rerunfailures.py#L485-L488

But on the server:

https://github.com/pytest-dev/pytest-rerunfailures/blob/02c2df72fcd6a0d320538a55c6b0cec510ee3289/pytest_rerunfailures.py#L339-L340

This can lead to inconsistent behavior with crash restarts. Sometimes the client side will create an identifier that consists of a full/absolute path while the server's identifier only contains the relative part. As a result, the server gets reruns as 0 and doesn't do a rerun.