### PR TITLE
Handle disabled pytest-xdist gracefully

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,11 @@ Changelog
 10.3 (unreleased)
 -----------------
 
-- Nothing changed yet.
+Bug fixes
++++++++++
+
+- Fix crash when pytest-xdist is installed but disabled.
+  (Thanks to `@mgorny <https://github.com/mgorny>`_ for the PR.)
 
 
 10.2 (2021-09-17)

--- a/pytest_rerunfailures.py
+++ b/pytest_rerunfailures.py
@@ -316,7 +316,8 @@ def pytest_configure(config):
         "between re-runs.",
     )
 
-    if HAS_PYTEST_HANDLECRASHITEM:
+    if config.pluginmanager.hasplugin("xdist") and HAS_PYTEST_HANDLECRASHITEM:
+        config.pluginmanager.register(XDistHooks())
         if is_master(config):
             config.failures_db = ServerStatusDB()
         else:
@@ -325,13 +326,12 @@ def pytest_configure(config):
         config.failures_db = StatusDB()  # no-op db
 
 
-if HAS_PYTEST_HANDLECRASHITEM:
-
-    def pytest_configure_node(node):
+class XDistHooks:
+    def pytest_configure_node(self, node):
         """xdist hook"""
         node.workerinput["sock_port"] = node.config.failures_db.sock_port
 
-    def pytest_handlecrashitem(crashitem, report, sched):
+    def pytest_handlecrashitem(self, crashitem, report, sched):
         """
         Return the crashitem from pending and collection.
         """

--- a/test_pytest_rerunfailures.py
+++ b/test_pytest_rerunfailures.py
@@ -194,7 +194,7 @@ def test_rerun_passes_after_temporary_test_crash(testdir):
         def test_pass():
             pass"""
     )
-    result = testdir.runpytest("-n", "1", "--reruns", "1", "-r", "R")
+    result = testdir.runpytest("-p", "xdist", "-n", "1", "--reruns", "1", "-r", "R")
     assert_outcomes(result, passed=2, rerun=1)
 
 


### PR DESCRIPTION
Currently, the plugin crashes when xdist is installed but explicitly disabled, e.g. via `-p no:xdist`. Modify the code to enable xdist-specific features only when the plugin manager explicitly indicates that it is available.

While at it, also make that one test explicitly pass `-p xdist` when xdist is available to make using `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1` easier.

Fixes #177.