### PR TITLE
replace pkg_resources with packaging+importlib.metadata

### DIFF
--- a/pytest_rerunfailures.py
+++ b/pytest_rerunfailures.py
@@ -13,9 +13,12 @@ from contextlib import suppress
 import pytest
 from _pytest.outcomes import fail
 from _pytest.runner import runtestprotocol
-from pkg_resources import DistributionNotFound
-from pkg_resources import get_distribution
-from pkg_resources import parse_version
+from packaging.version import parse as parse_version
+
+if sys.version_info >= (3, 8):
+    import importlib.metadata as importlib_metadata
+else:
+    import importlib_metadata
 
 HAS_RESULTLOG = False
 
@@ -50,10 +53,11 @@ def works_with_current_xdist():
 
     """
     try:
-        d = get_distribution("pytest-xdist")
-        return d.parsed_version >= parse_version("1.20")
-    except DistributionNotFound:
+        d = importlib_metadata.distribution("pytest-xdist")
+    except importlib_metadata.PackageNotFoundError:
         return None
+    else:
+        return parse_version(d.version) >= parse_version("1.20")
 
 
 # command line options

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,8 +41,9 @@ zip_safe = False
 py_modules = pytest_rerunfailures
 python_requires = >= 3.6
 install_requires =
-    setuptools >= 40.0
+    packaging >= 17.1
     pytest >= 5.3
+    importlib-metadata>=1;python_version<"3.8"
 
 [options.entry_points]
 pytest11 =

--- a/test_pytest_rerunfailures.py
+++ b/test_pytest_rerunfailures.py
@@ -3,7 +3,7 @@ import time
 from unittest import mock
 
 import pytest
-from pkg_resources import parse_version
+from packaging.version import parse as parse_version
 
 from pytest_rerunfailures import HAS_PYTEST_HANDLECRASHITEM
 


### PR DESCRIPTION
this has a pretty significant improvement on startup time (and this is with a fairly empty virtualenv, it's more pronounced the more packages that are installed):

### before

```console
$ best-of -- python3 -c 'import pytest_rerunfailures'
..........
best of 10: 0.108s
```

### after

```console
$ best-of -- python3 -c 'import pytest_rerunfailures'
..........
best of 10: 0.077s
```