### PR TITLE
fix: don't bind all ips

### DIFF
--- a/pytest_rerunfailures.py
+++ b/pytest_rerunfailures.py
@@ -440,7 +440,7 @@ class SocketDB(StatusDB):
 class ServerStatusDB(SocketDB):
     def __init__(self):
         super().__init__()
-        self.sock.bind(("", 0))
+        self.sock.bind(("localhost", 0))
         self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
 
         self.rerunfailures_db = {}


### PR DESCRIPTION
Binding all IPs is kind of Security issues and also very annoying when
the OS has a firewall blocking application doing such thing or opening a
popup to allow it (like the default MacOS or Windows firewall).

The client uses "localhost", so the server can only bind the ip
associated with the hostname "localhost".

This will avoid opening this tools to anyone on the network and avoid
having to configure windows or macos firewall to make pytest run.