### PR TITLE
Update dependencies:

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,29 +22,29 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [
-          "3.6",
           "3.7",
           "3.8",
           "3.9",
           "3.10",
+          "3.11",
           "pypy-3.7",
         ]
         pytest-version: [
-          "5.3.*",
-          "5.4.*",
           "6.0.*",
           "6.1.*",
           "6.2.*",
+          "7.0.*",
+          "7.1.*",
+          "7.2.*",
           "main",
         ]
         exclude:
           # Only pytest 6.2+ supports Python 3.10
-          - { python-version: "3.10", pytest-version: "5.3.*" }
-          - { python-version: "3.10", pytest-version: "5.4.*" }
           - { python-version: "3.10", pytest-version: "6.0.*" }
           - { python-version: "3.10", pytest-version: "6.1.*" }
-          # Main requires Python >= 3.7
-          - { python-version: "3.6", pytest-version: "main" }
+          # Only pytest 6.2+ supports Python 3.11
+          - { python-version: "3.11", pytest-version: "6.0.*" }
+          - { python-version: "3.11", pytest-version: "6.1.*" }
     steps:
       - uses: actions/checkout@v2
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,8 +1,15 @@
 Changelog
 =========
 
-10.3 (unreleased)
+11.0 (unreleased)
 -----------------
+
+Breaking changes
+++++++++++++++++
+
+- Drop support for Python 3.6.
+
+- Drop support for pytest < 6.
 
 Bug fixes
 +++++++++
@@ -16,6 +23,10 @@ Features
 ++++++++
 
 - Added option `--rerun-except` to rerun failed tests those are other than the mentioned Error.
+
+- Add support for Python 3.11.
+
+- Add support for pytest 7.0, 7.1, 7.2.
 
 
 10.2 (2021-09-17)

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ ignore =
 
 [metadata]
 name = pytest-rerunfailures
-version = 10.3.dev0
+version = 11.0.dev0
 url = https://github.com/pytest-dev/pytest-rerunfailures
 description = pytest plugin to re-run tests to eliminate flaky failures
 long_description = file: HEADER.rst, README.rst, CHANGES.rst
@@ -27,11 +27,11 @@ classifiers =
     Topic :: Software Development :: Testing
     Topic :: Utilities
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
@@ -39,7 +39,7 @@ classifiers =
 [options]
 zip_safe = False
 py_modules = pytest_rerunfailures
-python_requires = >= 3.6
+python_requires = >= 3.7
 install_requires =
     packaging >= 17.1
     pytest >= 5.3

--- a/tox.ini
+++ b/tox.ini
@@ -11,20 +11,21 @@ max-line-length = 88
 [tox]
 envlist =
     linting
-    py{36,37,38,39,py3}-pytest{53,54,60,61,62}
-    py{37,38,39,py3}-pytest{main}
-    py310-pytest{62,main}
-minversion = 3.17.1
+    py{37,38,39,py3}-pytest{60,61}
+    py{37,38,39,310,311,py3}-pytest{62,70,71,72}
+    py{37,38,39,310,311,py3}-pytest{main}
+minversion = 4.0
 
 [testenv]
 commands = pytest test_pytest_rerunfailures.py {posargs}
 deps =
     pytest-xdist
-    pytest53: pytest==5.3.*
-    pytest54: pytest==5.4.*
     pytest60: pytest==6.0.*
     pytest61: pytest==6.1.*
     pytest62: pytest==6.2.*
+    pytest70: pytest==7.0.*
+    pytest71: pytest==7.1.*
+    pytest72: pytest==7.2.*
     pytestmain: git+https://github.com/pytest-dev/pytest.git@main#egg=pytest
 
 [testenv:linting]


### PR DESCRIPTION
* Drop support for Python 3.6.
* Drop support for pytest < 6.
* Add support for Python 3.11.
* Add support for pytest 7.0, 7.1, 7.2.