### PR TITLE
Fix handling of --rerun-except arguments

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,8 +19,13 @@ Features
 Bug fixes
 +++++++++
 
--- Fix handling of ``--rerun-except`` and ``--only-rerun`` when used together,
-   and multiple instances of ``--rerun-except``.
+-- Failures are now rerun only if they match at least one ``--only-rerun``
+   pattern (if given) and none of the ``--rerun-except`` patterns. Previously,
+   using both ``--only-rerun`` and ``--rerun-except`` together could cause
+   failures to be rerun even if they did not match any ``--only-rerun``
+   pattern, and when using multiple ``--rerun-except`` patterns, all failures
+   would be rerun unless they matched every pattern.
+   (`#225 <https://github.com/pytest-dev/pytest-rerunfailures/issues/225>`_)
 
 
 11.1.2 (2023-03-09)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,11 @@ Features
 
 - Add ``only_rerun`` and ``rerun_except`` arguments to ``@pytest.mark.flaky`` marker.
 
+Bug fixes
++++++++++
+
+-- Fix handling of ``--rerun-except`` and ``--only-rerun`` when used together,
+   and multiple instances of ``--rerun-except``.
 
 11.1.2 (2023-03-09)
 -------------------


### PR DESCRIPTION
Previously, a failure had to match all --rerun-except arguments to prevent a test from rerunning.  Now it will not rerun if one or more are matched.

Additionally, if --only-rerun and --rerun-except are used together, a failure must match at least one --only-rerun pattern and none of the --rerun-except patterns for the test to be rerun.  Previously a test would be rerun if it matched neither --only-rerun nor --rerun-except.

Fixes #225