### PR TITLE
Fix crash with setup errors and --rerun-except flag

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Changelog
 - Fix crashitem names mismatch between client and server.
   (`#172 <https://github.com/pytest-dev/pytest-rerunfailures/issues/172>`_)
 
+- Fix crash when setup fails with --rerun-except flag.
 
 12.0 (2023-07-05)
 -----------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ Changelog
   (`#172 <https://github.com/pytest-dev/pytest-rerunfailures/issues/172>`_)
 
 - Fix crash when setup fails with --rerun-except flag.
+  (`#230 <https://github.com/pytest-dev/pytest-rerunfailures/issues/230>`_)
 
 12.0 (2023-07-05)
 -----------------

--- a/pytest_rerunfailures.py
+++ b/pytest_rerunfailures.py
@@ -278,8 +278,12 @@ def _matches_any_rerun_error(rerun_errors, report):
 
 def _matches_any_rerun_except_error(rerun_except_errors, report):
     for rerun_regex in rerun_except_errors:
-        if re.search(rerun_regex, report.longrepr.reprcrash.message):
-            return True
+        try:
+            if re.search(rerun_regex, report.longrepr.reprcrash.message):
+                return True
+        except AttributeError:
+            if re.search(rerun_regex, report.longreprtext):
+                return True
     return False
 
 

--- a/pytest_rerunfailures.py
+++ b/pytest_rerunfailures.py
@@ -282,17 +282,6 @@ def _try_match_reprcrash(rerun_errors, report):
     return False
 
 
-def _matches_any_rerun_except_error(rerun_except_errors, report):
-    for rerun_regex in rerun_except_errors:
-        try:
-            if re.search(rerun_regex, report.longrepr.reprcrash.message):
-                return True
-        except AttributeError:
-            if re.search(rerun_regex, report.longreprtext):
-                return True
-    return False
-
-
 def _should_hard_fail_on_error(item, report):
     if report.outcome != "failed":
         return False

--- a/test_pytest_rerunfailures.py
+++ b/test_pytest_rerunfailures.py
@@ -617,6 +617,26 @@ def test_rerun_except_and_only_rerun(
     )
 
 
+def test_rerun_except_passes_setup_errors(testdir):
+    testdir.makepyfile(
+        """
+        import pytest
+
+        @pytest.fixture()
+        def fixture_setup_fails(non_existent_fixture):
+            return 1
+
+        def test_will_not_run(fixture_setup_fails):
+            assert fixture_setup_fails==1"""
+    )
+
+    num_reruns = 1
+    pytest_args = ["--reruns", str(num_reruns), "--rerun-except", "ValueError"]
+    result = testdir.runpytest(*pytest_args)
+    assert result.ret != pytest.ExitCode.INTERNAL_ERROR
+    assert_outcomes(result, passed=0, error=1, rerun=num_reruns)
+
+
 @pytest.mark.parametrize(
     "condition, expected_reruns",
     [

--- a/test_pytest_rerunfailures.py
+++ b/test_pytest_rerunfailures.py
@@ -627,7 +627,7 @@ def test_rerun_except_passes_setup_errors(testdir):
             return 1
 
         def test_will_not_run(fixture_setup_fails):
-            assert fixture_setup_fails==1"""
+            assert fixture_setup_fails == 1"""
     )
 
     num_reruns = 1


### PR DESCRIPTION
This PR fixes internal errors on setup (non-existent fixtures etc) that occur when using --rerun-except flag.

I am wondering whether reruns should occur when failure happens on setup part of the test?