### PR TITLE
precommit: update min `py37`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
       rev: 23.11.0
       hooks:
           - id: black
-            args: [--safe, --quiet, --target-version, py36]
+            args: [--safe, --quiet, --target-version, py37]
     - repo: https://github.com/pre-commit/pre-commit-hooks
       rev: v4.5.0
       hooks:
@@ -30,7 +30,7 @@ repos:
       rev: v3.15.0
       hooks:
           - id: pyupgrade
-            args: [--py36-plus]
+            args: [--py37-plus]
     - repo: local
       hooks:
           - id: rst


### PR DESCRIPTION
the minimal package supported Python version is 3.7 so it makes sense to also align all used liters

https://github.com/pytest-dev/pytest-rerunfailures/blob/5f8fab9b551cf96b3f30930e63d9f19eb8a076d3/setup.cfg#L43

cc: @sallner @florianpilz @hugovk