### PR TITLE
Drop support for EOL Python 3.7 and bump GitHub Actions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,9 +2,7 @@ name: Lint
 
 on:
   push:
-    branches: [ master ]
   pull_request:
-    branches: [ master ]
     type: [ "opened", "reopened", "synchronize" ]
 
 env:
@@ -16,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cache/pip
@@ -30,7 +28,7 @@ jobs:
             lint-v1-
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.x'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,7 @@ name: Test
 
 on:
   push:
-    branches: [ master ]
   pull_request:
-    branches: [ master ]
     type: [ "opened", "reopened", "synchronize" ]
   schedule:
     - cron: '0 12 * * 0'  # run once a week on Sunday
@@ -22,13 +20,12 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [
-          "3.7",
           "3.8",
           "3.9",
           "3.10",
           "3.11",
           "3.12",
-          "pypy-3.9",
+          "pypy-3.10",
         ]
         pytest-version: [
           "7.0.*",
@@ -38,14 +35,11 @@ jobs:
           "7.4.*",
           "main",
         ]
-        exclude:
-          # pytest-main only supports Python 3.8+
-          - { python-version: "3.7", pytest-version: "main" }
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -55,7 +49,7 @@ jobs:
           echo "::set-output name=dir::$(pip cache dir)"
 
       - name: Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
           key:
@@ -88,10 +82,10 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.x'
           architecture: 'x64'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
       rev: 24.2.0
       hooks:
           - id: black
-            args: [--safe, --quiet, --target-version, py37]
+            args: [--safe, --quiet, --target-version, py38]
     - repo: https://github.com/pre-commit/pre-commit-hooks
       rev: v4.5.0
       hooks:
@@ -30,7 +30,7 @@ repos:
       rev: v3.15.1
       hooks:
           - id: pyupgrade
-            args: [--py37-plus]
+            args: [--py38-plus]
     - repo: local
       hooks:
           - id: rst

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,10 @@ Changelog
 13.1 (unreleased)
 -----------------
 
-- Nothing changed yet.
+Breaking changes
+++++++++++++++++
 
+- Drop support for Python 3.7.
 
 13.0 (2023-11-22)
 -----------------

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -29,13 +29,13 @@ Preparing Pull Requests
 
 #. Install `tox <https://tox.readthedocs.io/en/latest/>`_:
 
-   Tox is used to run all the tests and will automatically setup virtualenvs
+   tox is used to run all the tests and will automatically setup virtualenvs
    to run the tests in. Implicitly https://virtualenv.pypa.io/ is used::
 
     $ pip install tox
-    $ tox -e linting,py37
+    $ tox -e linting,py312
 
-#. Follow **PEP-8** for naming and `black <https://github.com/psf/black>`_ for formatting.
+#. Follow **PEP 8** for naming and `black <https://github.com/psf/black>`_ for formatting.
 
 #. Add a line item to the current **unreleased** version in ``CHANGES.rst``,
    unless the change is trivial.

--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ Requirements
 
 You will need the following prerequisites in order to use pytest-rerunfailures:
 
-- Python 3.7, up to 3.12, or PyPy3
+- Python 3.8+ or PyPy3
 - pytest 7.0 or newer
 
 This plugin can recover from a hard crash with the following optional

--- a/pytest_rerunfailures.py
+++ b/pytest_rerunfailures.py
@@ -1,4 +1,5 @@
 import hashlib
+import importlib.metadata
 import os
 import platform
 import re
@@ -14,11 +15,6 @@ import pytest
 from _pytest.outcomes import fail
 from _pytest.runner import runtestprotocol
 from packaging.version import parse as parse_version
-
-if sys.version_info >= (3, 8):
-    import importlib.metadata as importlib_metadata
-else:
-    import importlib_metadata
 
 try:
     from xdist.newhooks import pytest_handlecrashitem
@@ -39,8 +35,8 @@ def works_with_current_xdist():
 
     """
     try:
-        d = importlib_metadata.distribution("pytest-xdist")
-    except importlib_metadata.PackageNotFoundError:
+        d = importlib.metadata.distribution("pytest-xdist")
+    except importlib.metadata.PackageNotFoundError:
         return None
     else:
         return parse_version(d.version) >= parse_version("1.20")

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[bdist_wheel]
-universal = 0
-
 [check-manifest]
 ignore =
     .pre-commit-config.yaml
@@ -27,7 +24,6 @@ classifiers =
     Topic :: Software Development :: Testing
     Topic :: Utilities
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -40,11 +36,10 @@ classifiers =
 [options]
 zip_safe = False
 py_modules = pytest_rerunfailures
-python_requires = >= 3.7
+python_requires = >= 3.8
 install_requires =
     packaging >= 17.1
     pytest >= 7
-    importlib-metadata>=1;python_version<"3.8"
 
 [options.entry_points]
 pytest11 =

--- a/tox.ini
+++ b/tox.ini
@@ -11,8 +11,7 @@ max-line-length = 88
 [tox]
 envlist =
     linting
-    py{37,38,39,310,311,312,py3}-pytest{70,71,72,73,74}
-    py{38,39,310,311,312,py3}-pytest{main}
+    py{38,39,310,311,312,py3}-pytest{70,71,72,73,74,main}
 minversion = 4.0
 
 [testenv]


### PR DESCRIPTION
EOL since 2023-06-27.

<img width="789" alt="image" src="https://github.com/pytest-dev/pytest-rerunfailures/assets/1324225/0d6340ae-7875-4aa3-bd7c-cc3faf6f3222">

https://devguide.python.org/versions/