### PR TITLE
precommit: use Sphinx Lint check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,8 +31,7 @@ repos:
       hooks:
           - id: pyupgrade
             args: [--py37-plus]
-    - repo: https://github.com/rstcheck/rstcheck
-      rev: v6.2.0
+    - repo: https://github.com/sphinx-contrib/sphinx-lint
+      rev: v0.9.1
       hooks:
-        - id: rstcheck
-          additional_dependencies: [ ]  # can be omitted if empty
+        - id: sphinx-lint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,11 +31,8 @@ repos:
       hooks:
           - id: pyupgrade
             args: [--py37-plus]
-    - repo: local
+    - repo: https://github.com/rstcheck/rstcheck
+      rev: v6.2.0
       hooks:
-          - id: rst
-            name: rst
-            entry: rst-lint --encoding utf-8
-            files: ^(CHANGES.rst|README.rst)$
-            language: python
-            additional_dependencies: [pygments, restructuredtext_lint]
+        - id: rstcheck
+          additional_dependencies: [ ]  # can be omitted if empty

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,3 +35,4 @@ repos:
       rev: v0.9.1
       hooks:
         - id: sphinx-lint
+          args: [--enable=default-role]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -90,7 +90,7 @@ Bug fixes
 Features
 ++++++++
 
-- Expose `reruns` and `reruns_delay` through `pytest.ini` file.
+- Expose ``reruns`` and ``reruns_delay`` through ``pytest.ini`` file.
 
 
 11.0 (2023-01-12)
@@ -114,7 +114,7 @@ Bug fixes
 Features
 ++++++++
 
-- Added option `--rerun-except` to rerun failed tests those are other than the mentioned Error.
+- Added option ``--rerun-except`` to rerun failed tests those are other than the mentioned Error.
 
 - Add support for Python 3.11.
 
@@ -319,7 +319,7 @@ Bug fixes
 
 - Add support for Python 3.7.
 
-- Fix issue can occur when used together with `pytest-flake8`
+- Fix issue can occur when used together with ``pytest-flake8``
   (`#73 <https://github.com/pytest-dev/pytest-rerunfailures/issues/73>`_)
 
 
@@ -414,7 +414,7 @@ Bug fixes
 1.0.2 (2016-03-29)
 ------------------
 
-- Add support for `--resultlog` option by parsing reruns accordingly. (#28)
+- Add support for ``--resultlog`` option by parsing reruns accordingly. (#28)
 
 
 1.0.1 (2016-02-02)

--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,7 @@ Recover from hard crashes
 
 If one or more tests trigger a hard crash (for example: segfault), this plugin
 will ordinarily be unable to rerun the test. However, if a compatible version of
-pytest-xdist is installed, and the tests are run within pytest-xdist using the `-n`
+pytest-xdist is installed, and the tests are run within pytest-xdist using the ``-n``
 flag, this plugin will be able to rerun crashed tests, assuming the workers and
 controller are on the same LAN (this assumption is valid for almost all cases
 because most of the time the workers and controller are on the same computer).


### PR DESCRIPTION
Just a suggestion: shall we use this hook instead of local and consecutively fix duplicated reference targets?

cc: @hugovk 