### PR TITLE
Fix Missing Teardown operations for fixtures

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog
 13.1 (unreleased)
 -----------------
 
-- Nothing changed yet.
+- Fix missing teardown for non-function scoped fixtures when using only_rerun or rerun_except queries.
+  (`#234 <https://github.com/pytest-dev/pytest-rerunfailures/issues/234>`_)
+  and (`#241 <https://github.com/pytest-dev/pytest-rerunfailures/issues/241>`_)
 
 
 13.0 (2023-11-22)

--- a/pytest_rerunfailures.py
+++ b/pytest_rerunfailures.py
@@ -304,7 +304,7 @@ def _should_hard_fail_on_error(item, report):
 
 def _should_not_rerun(item, report, reruns):
     xfail = hasattr(report, "wasxfail")
-    is_terminal_error = _should_hard_fail_on_error(item, report)
+    is_terminal_error = item._terminal_errors[report.when]
     condition = get_reruns_condition(item)
     return (
         item.execution_count > reruns
@@ -487,7 +487,15 @@ def pytest_runtest_teardown(item, nextitem):
         return
 
     _test_failed_statuses = getattr(item, "_test_failed_statuses", {})
-    if item.execution_count <= reruns and any(_test_failed_statuses.values()):
+
+    # Only remove non-function level actions from the stack if the test is to be re-run
+    # Exceeding re-run limits, being free of failue statuses, and encountering
+    # allowable exceptions indicate that the test is not to be re-ran.
+    if (
+        item.execution_count <= reruns
+        and any(_test_failed_statuses.values())
+        and not any(item._terminal_errors.values())
+    ):
         # clean cashed results from any level of setups
         _remove_cached_results_from_failed_fixtures(item)
 
@@ -504,9 +512,15 @@ def pytest_runtest_makereport(item, call):
     if result.when == "setup":
         # clean failed statuses at the beginning of each test/rerun
         setattr(item, "_test_failed_statuses", {})
+
+        # create a dict to store error-check results for each stage
+        setattr(item, "_terminal_errors", {})
+
     _test_failed_statuses = getattr(item, "_test_failed_statuses", {})
     _test_failed_statuses[result.when] = result.failed
     item._test_failed_statuses = _test_failed_statuses
+
+    item._terminal_errors[result.when] = _should_hard_fail_on_error(item, result)
 
 
 def pytest_runtest_protocol(item, nextitem):


### PR DESCRIPTION
When using the only_rerun and rerun_except queries (or both), the plug-in was removing the teardown operations from the call-stack before checking to see if the test should be re-run. This resulted in the stack having all fixture operations removed that did not correspond to a function fixture.

This commmit adds a private variable to each test item that keeps track of whether a test encountered a terminal error. The plugin now checks if a test has encountered a terminal error before attempting to clear the stack.

This commit fixes:
- #241: https://github.com/pytest-dev/pytest-rerunfailures/issues/241
- #234: https://github.com/pytest-dev/pytest-rerunfailures/issues/234