### PR TITLE
Fix Missing Fixture Teardown operations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,13 @@ Changelog
 13.1 (unreleased)
 -----------------
 
+Bug fixes
++++++++++
+
+- Fix missing teardown for non-function scoped fixtures when using only_rerun or rerun_except queries.
+  (`#234 <https://github.com/pytest-dev/pytest-rerunfailures/issues/234>`_)
+  and (`#241 <https://github.com/pytest-dev/pytest-rerunfailures/issues/241>`_)
+
 Breaking changes
 ++++++++++++++++
 

--- a/src/pytest_rerunfailures.py
+++ b/src/pytest_rerunfailures.py
@@ -481,7 +481,15 @@ def pytest_runtest_teardown(item, nextitem):
         return
 
     _test_failed_statuses = getattr(item, "_test_failed_statuses", {})
-    if item.execution_count <= reruns and any(_test_failed_statuses.values()):
+
+    # Only remove non-function level actions from the stack if the test is to be re-run
+    # Exceeding re-run limits, being free of failue statuses, and encountering
+    # allowable exceptions indicate that the test is not to be re-ran.
+    if (
+        item.execution_count <= reruns
+        and any(_test_failed_statuses.values())
+        and not any(item._terminal_errors.values())
+    ):
         # clean cashed results from any level of setups
         _remove_cached_results_from_failed_fixtures(item)
 
@@ -498,9 +506,15 @@ def pytest_runtest_makereport(item, call):
     if result.when == "setup":
         # clean failed statuses at the beginning of each test/rerun
         setattr(item, "_test_failed_statuses", {})
+
+        # create a dict to store error-check results for each stage
+        setattr(item, "_terminal_errors", {})
+
     _test_failed_statuses = getattr(item, "_test_failed_statuses", {})
     _test_failed_statuses[result.when] = result.failed
     item._test_failed_statuses = _test_failed_statuses
+
+    item._terminal_errors[result.when] = _should_hard_fail_on_error(item, result)
 
 
 def pytest_runtest_protocol(item, nextitem):


### PR DESCRIPTION
When using the only_rerun and rerun_except queries (or both), the plug-in was removing the teardown operations from the call-stack before checking to see if the test should be re-run. This resulted in the stack having all fixture operations removed that did not correspond to a function fixture.

This commit adds a private variable to each test item that keeps track of whether a test encountered a terminal error. The plugin now checks if a test has encountered a terminal error before attempting to clear the stack.

- Fixes #241
- Fixes #234