### PR TITLE
fix compatibility with pytest 8.2 by restoring deleted finalizers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 14.1 (unreleased)
 -----------------
 
-- Nothing changed yet.
+- Fix compatibility with pytest 8.2.
+  (`#267 <https://github.com/pytest-dev/pytest-rerunfailures/issues/267>`_)
 
 
 14.0 (2024-03-13)

--- a/src/pytest_rerunfailures.py
+++ b/src/pytest_rerunfailures.py
@@ -468,6 +468,9 @@ class ClientStatusDB(SocketDB):
         return int(self._sock_recv(self.sock))
 
 
+suspended_finalizers = {}
+
+
 def pytest_runtest_teardown(item, nextitem):
     reruns = get_reruns_count(item)
     if reruns is None:
@@ -490,13 +493,20 @@ def pytest_runtest_teardown(item, nextitem):
         and any(_test_failed_statuses.values())
         and not any(item._terminal_errors.values())
     ):
-        # clean cashed results from any level of setups
+        # clean cached results from any level of setups
         _remove_cached_results_from_failed_fixtures(item)
 
         if item in item.session._setupstate.stack:
             for key in list(item.session._setupstate.stack.keys()):
                 if key != item:
+                    # only the first finalizer contains the correct teardowns
+                    if key not in suspended_finalizers:
+                        suspended_finalizers[key] = item.session._setupstate.stack[key]
                     del item.session._setupstate.stack[key]
+    else:
+        # restore suspended finalizers
+        item.session._setupstate.stack.update(suspended_finalizers)
+        suspended_finalizers.clear()
 
 
 @pytest.hookimpl(hookwrapper=True)


### PR DESCRIPTION
Fixes #267

The problem in #267 arose from https://github.com/pytest-dev/pytest/pull/11833, which made pytest not add finalizers for cached fixtures.
`pytest_runtest_teardown` relied on cached fixtures getting their finalizers repeatedly re-added, as it deleted all(?) finalizers on every re-run. This PR makes sure to save away those finalizers, so we can add them back when we're done rerunning and let them execute.

I suspect the current solution will break with xdist or something, given that `suspended_finalizers` is a global dict. So it'd probably be more prudent to do something with the database?

This is my first time looking at pytest-rerunfailures, so I'd love if any current maintainers wanted to have opinions or even finish up the PR now that I've mostly figured out the messy part.