### PR TITLE
Update versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,19 +20,19 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [
-          "3.8",
           "3.9",
           "3.10",
           "3.11",
           "3.12",
+          "3.13",
           "pypy-3.10",
         ]
         pytest-version: [
-          "7.2.*",
-          "7.3.*",
           "7.4.*",
           "8.0.*",
           "8.1.*",
+          "8.2.*",
+          "8.3.*",
           "main",
         ]
     steps:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,12 +1,23 @@
 Changelog
 =========
 
-14.1 (unreleased)
+15.0 (unreleased)
 -----------------
+
+Breaking changes
+++++++++++++++++
+
+- Drop support for Python 3.8.
+
+- Drop support for pytest < 7.4.
+
+Features
+++++++++
 
 - Fix compatibility with pytest 8.2.
   (`#267 <https://github.com/pytest-dev/pytest-rerunfailures/issues/267>`_)
 
+- Add support for pytest 8.2, 8.3.
 
 14.0 (2024-03-13)
 -----------------

--- a/README.rst
+++ b/README.rst
@@ -19,8 +19,8 @@ Requirements
 
 You will need the following prerequisites in order to use pytest-rerunfailures:
 
-- Python 3.8+ or PyPy3
-- pytest 7.2 or newer
+- Python 3.9+ or PyPy3
+- pytest 7.4 or newer
 
 This plugin can recover from a hard crash with the following optional
 prerequisites:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ ignore = [".pre-commit-config.yaml"]
 
 [project]
 name = "pytest-rerunfailures"
-version = "14.1.dev0"
+version = "15.0.dev0"
 description = "pytest plugin to re-run tests to eliminate flaky failures"
 dynamic = [
   "readme",
@@ -38,6 +38,7 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
   "Topic :: Software Development :: Quality Assurance",
@@ -46,7 +47,7 @@ classifiers = [
 ]
 dependencies = [
   "packaging>=17.1",
-  "pytest>=7.2",
+  "pytest>=7.4",
 ]
 urls = {Homepage = "https://github.com/pytest-dev/pytest-rerunfailures"}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ classifiers = [
 ]
 dependencies = [
   "packaging>=17.1",
-  "pytest>=7.4,!=8.2.2",
+  "pytest!=8.2.2,>=7.4",
 ]
 urls = {Homepage = "https://github.com/pytest-dev/pytest-rerunfailures"}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ keywords = [
 ]
 license = {text = "Mozilla Public License 2.0 (MPL 2.0)"}
 authors = [{name = "Leah Klearman", email = "lklrmn@gmail.com"}]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Framework :: Pytest",
@@ -33,7 +33,6 @@ classifiers = [
   "Operating System :: Microsoft :: Windows",
   "Operating System :: POSIX",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ classifiers = [
 ]
 dependencies = [
   "packaging>=17.1",
-  "pytest>=7.4",
+  "pytest>=7.4,!=8.2.2",
 ]
 urls = {Homepage = "https://github.com/pytest-dev/pytest-rerunfailures"}
 

--- a/tox.ini
+++ b/tox.ini
@@ -11,18 +11,18 @@ max-line-length = 88
 [tox]
 envlist =
     linting
-    py{38,39,310,311,312,py3}-pytest{72,73,74,80,81,main}
+    py{39,310,311,312,313,py3}-pytest{74,80,81,82,83,main}
 minversion = 4.0
 
 [testenv]
 commands = pytest tests/ {posargs}
 deps =
     pytest-xdist
-    pytest72: pytest==7.2.*
-    pytest73: pytest==7.3.*
     pytest74: pytest==7.4.*
     pytest80: pytest==8.0.*
     pytest81: pytest==8.1.*
+    pytest82: pytest==8.2.*
+    pytest83: pytest==8.3.*
     pytestmain: git+https://github.com/pytest-dev/pytest.git@main#egg=pytest
 
 [testenv:linting]


### PR DESCRIPTION
- Drop support for Python 3.8
- Drop support for pytest < 7.4
- Add support for Python 3.13
- Add support for pytest 8.2 and 8.3.

Fixes #267 