### PR TITLE
Adjust `--fail-on-flaky` behavior to improve exit status handling

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,12 @@ Changelog
 15.1 (unreleased)
 -----------------
 
-- Nothing changed yet.
+Bug fixes
++++++++++
+
+- Fix ``--fail-on-flaky`` option to fail the test run with custom exit code
+  only when reruns are detected.
+  (`#287 <https://github.com/pytest-dev/pytest-rerunfailures/issues/287>`_)
 
 
 15.0 (2024-11-20)

--- a/src/pytest_rerunfailures.py
+++ b/src/pytest_rerunfailures.py
@@ -625,9 +625,12 @@ def show_rerun(terminalreporter, lines):
 
 @pytest.hookimpl(trylast=True)
 def pytest_sessionfinish(session, exitstatus):
+    # type: (pytest.Session, int) -> None
     if exitstatus != 0:
         return
 
     if session.config.option.fail_on_flaky:
-        if session.config.getvalue("reruns") > 0:
-            session.exitstatus = 7
+        for item in session.items:
+            if item.execution_count > 1:
+                session.exitstatus = 7
+                break

--- a/src/pytest_rerunfailures.py
+++ b/src/pytest_rerunfailures.py
@@ -625,12 +625,14 @@ def show_rerun(terminalreporter, lines):
 
 @pytest.hookimpl(trylast=True)
 def pytest_sessionfinish(session, exitstatus):
-    # type: (pytest.Session, int) -> None
     if exitstatus != 0:
         return
 
     if session.config.option.fail_on_flaky:
         for item in session.items:
+            if not hasattr(item, "execution_count"):
+                # no rerun requested
+                continue
             if item.execution_count > 1:
                 session.exitstatus = 7
                 break

--- a/tests/test_pytest_rerunfailures.py
+++ b/tests/test_pytest_rerunfailures.py
@@ -242,7 +242,7 @@ def test_run_with_mark_and_fail_on_flaky_succeeds_if_all_tests_pass_without_reru
         def test_unmarked_pass():
             assert True
     """)
-    result = testdir.runpytest("--reruns", "1", "--fail-on-flaky")
+    result = testdir.runpytest("--fail-on-flaky")
     assert_outcomes(result, passed=2, rerun=0)
     assert result.ret == pytest.ExitCode.OK
 


### PR DESCRIPTION
Enhance the `--fail-on-flaky` option to set a custom exit status when tests are retried and fail. This change ensures that the exit status reflects the presence of flaky tests more accurately. Additional tests validate the new behavior.

Fixes #287 