### PR TITLE
Use SPDX license identifier

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,6 +28,6 @@ repos:
         - id: pyproject-fmt
           additional_dependencies: [ tox ]
     - repo: https://github.com/abravalheri/validate-pyproject
-      rev: v0.16
+      rev: v0.24.1
       hooks:
         - id: validate-pyproject

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,8 @@ Bug fixes
   only when reruns are detected.
   (`#287 <https://github.com/pytest-dev/pytest-rerunfailures/issues/287>`_)
 
+- Switched to using the SPDX license identifier in the project metadata.
+
 
 15.0 (2024-11-20)
 -----------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 build-backend = "setuptools.build_meta"
 requires = [
-  "setuptools>=77",
+  "setuptools>=40",
 ]
 
 [tool.check-manifest]
@@ -20,7 +20,7 @@ keywords = [
   "pytest",
   "rerun",
 ]
-license = "MPL-2.0"
+license.text = "MPL-2.0"
 authors = [{name = "Leah Klearman", email = "lklrmn@gmail.com"}]
 requires-python = ">=3.9"
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 build-backend = "setuptools.build_meta"
 requires = [
-  "setuptools>=40",
+  "setuptools>=77",
 ]
 
 [tool.check-manifest]
@@ -20,14 +20,13 @@ keywords = [
   "pytest",
   "rerun",
 ]
-license = {text = "Mozilla Public License 2.0 (MPL 2.0)"}
+license = "MPL-2.0"
 authors = [{name = "Leah Klearman", email = "lklrmn@gmail.com"}]
 requires-python = ">=3.9"
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Framework :: Pytest",
   "Intended Audience :: Developers",
-  "License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)",
   "Operating System :: MacOS :: MacOS X",
   "Operating System :: Microsoft :: Windows",
   "Operating System :: POSIX",


### PR DESCRIPTION
[PEP 639](https://peps.python.org/pep-0639/) added support for SPDX license identifier.
https://spdx.org/licenses/MPL-2.0.html

Metadata diff
```diff
 ...
-License: Mozilla Public License 2.0 (MPL 2.0)
+License-Expression: MPL-2.0
 ...
-Classifier: License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)
 ...
 License-File: LICENSE
 ...
```