### PR TITLE
Update exception filtering to match against actual exception

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,12 @@ Bug fixes
 
 - Switched to using the SPDX license identifier in the project metadata.
 
+Other changes
++++++++++++++
+
+- Change exception filtering logic to match ``AssertionError`` raised via
+  ``assert`` statements when filtering by "AssertionError".
+  (`#292 <https://github.com/pytest-dev/pytest-rerunfailures/issues/292>`_)
 
 15.0 (2024-11-20)
 -----------------

--- a/README.rst
+++ b/README.rst
@@ -118,13 +118,6 @@ would only rerun those errors that does not match with ``AssertionError`` or ``O
 
    $ pytest --reruns 5 --rerun-except AssertionError --rerun-except OSError
 
-.. note::
-
-   When the ```AssertionError``` comes from the use of the ``assert`` keyword,
-   use ``--rerun-except assert`` instead::
-
-   $ pytest --reruns 5 --rerun-except assert
-
 Re-run individual failures
 --------------------------
 

--- a/tests/test_pytest_rerunfailures.py
+++ b/tests/test_pytest_rerunfailures.py
@@ -598,12 +598,18 @@ def test_pytest_runtest_logfinish_is_called(testdir):
     ],
 )
 def test_only_rerun_flag(testdir, only_rerun_texts, should_rerun):
-    testdir.makepyfile('def test_only_rerun(): raise AssertionError("ERR")')
+    testdir.makepyfile("""
+        def test_only_rerun1():
+            raise AssertionError("ERR")
 
-    num_failed = 1
+        def test_only_rerun2():
+            assert False, "ERR"
+    """)
+
+    num_failed = 2
     num_passed = 0
-    num_reruns = 1
-    num_reruns_actual = num_reruns if should_rerun else 0
+    num_reruns = 2
+    num_reruns_actual = num_reruns * 2 if should_rerun else 0
 
     pytest_args = ["--reruns", str(num_reruns)]
     for only_rerun_text in only_rerun_texts:
@@ -1205,7 +1211,7 @@ def test_exception_matches_rerun_except_query(testdir):
                 raise AssertionError("fail")
 
             def test_2(self):
-                assert False
+                raise ValueError("fail")
 
     """
     )


### PR DESCRIPTION
Fixes https://github.com/pytest-dev/pytest-rerunfailures/issues/292

This PR aims to change [this function](https://github.com/pytest-dev/pytest-rerunfailures/blob/15.0/src/pytest_rerunfailures.py#L269-L277) to check specified `only_rerun` and `rerun_except` value(s) against the actual exception, instead of using `report.longrepr.reprcrash.message` or `report.longreprtext`.

I wasn't sure why `report.longrepr.reprcrash.message` and `report.longreprtext` are currently used. So please disregard/close the PR if my change looks invalid or would break something. 
