### PR TITLE
Upper bound for pytest version, since >= 8.2 is not supported

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ classifiers = [
 ]
 dependencies = [
   "packaging>=17.1",
-  "pytest!=8.2.2,>=7.4",
+  "pytest<8.2,>=7.4",
 ]
 urls = {Homepage = "https://github.com/pytest-dev/pytest-rerunfailures"}
 


### PR DESCRIPTION
According to the following PRs [^1], [^2] version 8.2 is not supported and that's what we encountered while trying to use fixtures with yield statement on pytest 8.3.5. Downgrading seemingly fixed the problem.

[^1]: https://github.com/pytest-dev/pytest-rerunfailures/issues/272#issuecomment-2348152479
[^2]: https://github.com/pytest-dev/pytest-rerunfailures/issues/274#issuecomment-2348149775