### PR TITLE
Allow to pass a callable condition to the `flaky` marker

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,10 @@ Changelog
 15.2 (unreleased)
 -----------------
 
-- Nothing changed yet.
+- Allow ``@pytest.mark.flaky(condition)`` to accept a callable or a string
+  to be evaluated. The evaluated string has access to the exception instance
+  via the ``error`` object.
+  (`#230 <https://github.com/pytest-dev/pytest-rerunfailures/issues/230>`_)
 
 
 15.1 (2025-05-08)

--- a/docs/mark.rst
+++ b/docs/mark.rst
@@ -79,7 +79,7 @@ test failure).
 
 **Callable condition:**
 
-The condition can be a callable (e.g., a function or a lambda) that will be
+The condition can be a callable (e. g., a function or a lambda) that will be
 passed the exception instance that caused the test failure. The test will be
 rerun only if the callable returns ``True``.
 

--- a/tests/test_pytest_rerunfailures.py
+++ b/tests/test_pytest_rerunfailures.py
@@ -1357,3 +1357,167 @@ def test_exception_match_only_rerun_in_dual_query(testdir):
     result = testdir.runpytest()
     assert_outcomes(result, passed=0, failed=1, rerun=1)
     result.stdout.fnmatch_lines("session teardown")
+
+
+def test_rerun_with_callable_condition(testdir):
+    testdir.makepyfile(
+        """
+        import pytest
+
+        def my_condition(error):
+            return isinstance(error, ValueError)
+
+        @pytest.mark.flaky(reruns=2, condition=my_condition)
+        def test_fail_two():
+            raise ValueError("some error")
+
+        @pytest.mark.flaky(reruns=2, condition=my_condition)
+        def test_fail_two_but_no_rerun():
+            raise NameError("some other error")
+
+        """
+    )
+    result = testdir.runpytest()
+    assert_outcomes(result, passed=0, failed=2, rerun=2)
+
+
+def test_rerun_with_lambda_condition(testdir):
+    testdir.makepyfile(
+        """
+        import pytest
+
+        @pytest.mark.flaky(reruns=2, condition=lambda e: isinstance(e, ValueError))
+        def test_fail_two():
+            raise ValueError("some error")
+
+        @pytest.mark.flaky(reruns=2, condition=lambda e: isinstance(e, ValueError))
+        def test_fail_two_but_no_rerun():
+            raise NameError("some other error")
+
+        """
+    )
+    result = testdir.runpytest()
+    assert_outcomes(result, passed=0, failed=2, rerun=2)
+
+
+def test_rerun_with_string_condition_and_error_object(testdir):
+    testdir.makepyfile(
+        """
+        import pytest
+
+        class MyError(Exception):
+            def __init__(self, code):
+                self.code = code
+
+        @pytest.mark.flaky(reruns=2, condition="error.code == 123")
+        def test_fail_two():
+            raise MyError(123)
+
+        @pytest.mark.flaky(reruns=2, condition="error.code == 123")
+        def test_fail_two_but_no_rerun():
+            raise MyError(456)
+
+        """
+    )
+    result = testdir.runpytest()
+    assert_outcomes(result, passed=0, failed=2, rerun=2)
+
+
+def test_reruns_with_callable_condition(testdir):
+    testdir.makepyfile(
+        """
+        import pytest
+
+        @pytest.mark.flaky(reruns=2, condition=lambda err: True)
+        def test_fail_two():
+            assert False"""
+    )
+
+    result = testdir.runpytest()
+    assert_outcomes(result, passed=0, failed=1, rerun=2)
+
+
+def test_reruns_with_callable_condition_returning_false(testdir):
+    testdir.makepyfile(
+        """
+        import pytest
+
+        @pytest.mark.flaky(reruns=2, condition=lambda err: False)
+        def test_fail_two():
+            assert False"""
+    )
+
+    result = testdir.runpytest()
+    assert_outcomes(result, passed=0, failed=1, rerun=0)
+
+
+def test_reruns_with_callable_condition_inspecting_exception(testdir):
+    testdir.makepyfile(
+        """
+        import pytest
+
+        class CustomError(Exception):
+            def __init__(self, code):
+                self.code = code
+
+        def should_rerun(err):
+            return err.code == 123
+
+        @pytest.mark.flaky(reruns=2, condition=should_rerun)
+        def test_fail_two():
+            raise CustomError(123)
+
+        @pytest.mark.flaky(reruns=2, condition=should_rerun)
+        def test_fail_three():
+            raise CustomError(456)
+        """
+    )
+
+    result = testdir.runpytest()
+    assert_outcomes(result, passed=0, failed=2, rerun=2)
+
+
+def test_reruns_with_string_condition_using_error(testdir):
+    testdir.makepyfile(
+        """
+        import pytest
+
+        class CustomError(Exception):
+            def __init__(self, code):
+                self.code = code
+
+        @pytest.mark.flaky(reruns=2, condition=\"error.code == 123\")
+        def test_fail_two():
+            raise CustomError(123)
+
+        @pytest.mark.flaky(reruns=2, condition=\"error.code == 456\")
+        def test_fail_three():
+            raise CustomError(123)
+
+        """
+    )
+
+    result = testdir.runpytest()
+    assert_outcomes(result, passed=0, failed=2, rerun=2)
+
+
+def test_reruns_with_callable_condition_raising_exception(testdir):
+    testdir.makepyfile(
+        """
+        import pytest
+
+        def condition(err):
+            raise ValueError(\"Whoops!\")
+
+        @pytest.mark.flaky(reruns=2, condition=condition)
+        def test_fail_two():
+            assert False
+        """
+    )
+
+    result = testdir.runpytest()
+    assert_outcomes(result, passed=0, failed=1, rerun=0)
+    result.stdout.fnmatch_lines([
+        "*UserWarning: Error evaluating 'flaky' condition as a callable*",
+        "*ValueError: Whoops!*",
+    ])


### PR DESCRIPTION
Closes https://github.com/pytest-dev/pytest-rerunfailures/issues/230