### PR TITLE
Add support for Python 3.14

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,7 +16,7 @@ jobs:
     name: Docs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python 3.13
         uses: actions/setup-python@v5

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,10 +18,10 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - name: Set up Python 3.13
+      - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.13
+          python-version: '3.x'
 
       - name: Get pip cache dir
         id: pip-cache

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Cache
         uses: actions/cache@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
           "main",
         ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
@@ -82,7 +82,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,8 @@ jobs:
           "3.11",
           "3.12",
           "3.13",
-          "pypy-3.10",
+          "3.14",
+          "pypy-3.11",
         ]
         pytest-version: [
           "8.0.*",
@@ -42,6 +43,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
 
       - name: Get pip cache dir
         id: pip-cache

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,8 @@ Features
 
 - Add support for pytest 8.4.x.
 
+- Add support for upcoming Python 3.14.
+
 - Allow ``@pytest.mark.flaky(condition)`` to accept a callable or a string
   to be evaluated. The evaluated string has access to the exception instance
   via the ``error`` object.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
   "Topic :: Software Development :: Quality Assurance",

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ max-line-length = 88
 [tox]
 envlist =
     linting
-    py{39,310,311,312,313,py3}-pytest{80,81,82,83,84,main}
+    py{39,310,311,312,313,314,py3}-pytest{80,81,82,83,84,main}
     docs
 minversion = 4.0
 


### PR DESCRIPTION
The Python 3.14 release candidate is out. 🚀 

The 3.14 release manager (👋 hi, that's me!) [said](https://discuss.python.org/t/python-3-14-0rc2-and-3-13-7-are-go/102403):

> ## Call to action
> 
> We **_strongly encourage_** maintainers of third-party Python projects to prepare their projects for 3.14 during this phase, and publish Python 3.14 wheels on PyPI to be ready for the final release of 3.14.0, and to help other projects do their own testing. Any binary wheels built against Python 3.14.0rc1 **_will work_** with future versions of Python 3.14. As always, report any issues to [the Python bug tracker](https://github.com/python/cpython/issues).

This also updates PyPy3.10 to PyPy3.11 in the CI: https://pypy.org/posts/2025/07/pypy-v7320-release.html
