### PR TITLE
Add a `--force-reruns` to override rerun count globally

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,9 @@ Changelog
 
 - Changed "localhost" to "127.0.0.1" to avoid bad hostname resolution
 
+- Added ``--force-reruns`` to override rerun count globally.
+  Fixes `#306 <https://github.com/pytest-dev/pytest-rerunfailures/issues/306>`_.
+
 16.0.1 (2025-09-02)
 -------------------
 

--- a/README.rst
+++ b/README.rst
@@ -190,6 +190,16 @@ You can use ``@pytest.mark.flaky(condition)`` similarly as ``@pytest.mark.skipif
 
 Note that the test will re-run for any ``condition`` that is truthy.
 
+Force rerun count
+-----------------
+
+To force a specific re-run count globally, irrespectively of the number
+of re-runs specified in test markers, pass ``--force-reruns``:
+
+.. code-block:: bash
+
+   $ pytest --force-reruns 5
+
 Output
 ------
 

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -1,6 +1,22 @@
 Command Line Interface Options
 ==============================
 
+.. option:: --force-reruns
+
+   **Description**:
+       Force specified number of reruns, irrespectively of the number passed to pytest markers.
+
+   **Type**:
+       Integer
+
+   **Default**:
+       Not set (must be provided)
+
+   **Example**:
+       .. code-block:: bash
+
+           pytest --force-reruns 5
+
 .. option:: --only-rerun
 
    **Description**:

--- a/src/pytest_rerunfailures.py
+++ b/src/pytest_rerunfailures.py
@@ -52,6 +52,14 @@ def pytest_addoption(parser):
         "rerunfailures", "re-run failing tests to eliminate flaky failures"
     )
     group._addoption(
+        "--force-reruns",
+        action="store",
+        dest="force_reruns",
+        type=int,
+        help="Force rerunning all tests the specified number of times, "
+        "irrespectively of individual test markers.",
+    )
+    group._addoption(
         "--only-rerun",
         action="append",
         dest="only_rerun",
@@ -112,6 +120,10 @@ def _get_marker(item):
 
 
 def get_reruns_count(item):
+    reruns = item.session.config.getvalue("force_reruns")
+    if reruns is not None:
+        return reruns
+
     rerun_marker = _get_marker(item)
     # use the marker as a priority over the global setting.
     if rerun_marker is not None:

--- a/tests/test_pytest_rerunfailures.py
+++ b/tests/test_pytest_rerunfailures.py
@@ -1357,3 +1357,19 @@ def test_exception_match_only_rerun_in_dual_query(testdir):
     result = testdir.runpytest()
     assert_outcomes(result, passed=0, failed=1, rerun=1)
     result.stdout.fnmatch_lines("session teardown")
+
+
+@pytest.mark.parametrize("mark_params", ["", "reruns=1"])
+def test_force_reruns(testdir, mark_params):
+    testdir.makepyfile(
+        f"""
+        import pytest
+
+        @pytest.mark.flaky({mark_params})
+        def test_fail():
+            assert False
+    """
+    )
+
+    result = testdir.runpytest("--force-reruns", "3")
+    assert_outcomes(result, passed=0, failed=1, rerun=3)


### PR DESCRIPTION
Add a new `--force-reruns` command-line option that can be used to override the rerun count globally, irrespectively of individual test markers.

Fixes #306.