### PR TITLE
Fix `NotImplementedError` crash when using xdist schedulers without `mark_test_pending`

### DIFF
--- a/src/pytest_rerunfailures.py
+++ b/src/pytest_rerunfailures.py
@@ -353,15 +353,17 @@ class XDistHooks:
                 sched.mark_test_pending(crashitem)
                 report.outcome = "rerun"
             except NotImplementedError:
-                # Some schedulers (like LoadScopeScheduling) don't implement mark_test_pending
+                # Some schedulers (like LoadScopeScheduling) don't implement
+                # mark_test_pending
                 # In this case, we can't reschedule the crashed test for rerun
                 # Mark it as failed with a clear message about why it couldn't be rerun
                 report.outcome = "failed"
-                if not hasattr(report, 'longrepr') or report.longrepr is None:
+                if not hasattr(report, "longrepr") or report.longrepr is None:
                     error_msg = (
-                        f"Test crashed and could not be rescheduled for rerun. "
+                        "Test crashed and could not be rescheduled for rerun. "
                         f"The scheduler '{sched.__class__.__name__}' does not support "
-                        f"rescheduling crashed tests (mark_test_pending not implemented). "
+                        "rescheduling crashed tests "
+                        "(mark_test_pending not implemented). "
                         f"Remaining reruns: {reruns - db.get_test_failures(crashitem)}"
                     )
                     report.longrepr = error_msg

--- a/src/pytest_rerunfailures.py
+++ b/src/pytest_rerunfailures.py
@@ -372,11 +372,11 @@ class XDistHooks:
                 report.outcome = "failed"
                 if not hasattr(report, "longrepr") or report.longrepr is None:
                     error_msg = (
-                        "Test crashed and could not be rescheduled for rerun. "
-                        f"The scheduler '{sched.__class__.__name__}' does not support "
-                        "rescheduling crashed tests "
-                        "(mark_test_pending not implemented). "
-                        f"Remaining reruns: {reruns - db.get_test_failures(crashitem)}"
+                        "Test crashed and could not be rescheduled for rerun."
+                        f" The scheduler '{sched.__class__.__name__}' does not support"
+                        " rescheduling crashed tests"
+                        " (mark_test_pending not implemented)."
+                        f" Remaining reruns: {reruns - db.get_test_failures(crashitem)}"
                     )
                     report.longrepr = error_msg
 


### PR DESCRIPTION
Handle gracefully when pytest-xdist schedulers (like `LoadScopeScheduling`) don't implement `mark_test_pending` by catching `NotImplementedError` and failing the test with a clear message instead of crashing the test run.

When a test crashes and cannot be rescheduled:
- Set report outcome to "failed" with informative error message
- Explain which scheduler lacks rescheduling support
- Show remaining rerun count that couldn't be used
- Continue test execution instead of internal crash

Fixes #247