### PR TITLE
Preserve session and module teardown when fixture teardown fails

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 16.2 (unreleased)
 -----------------
 
-- Nothing changed yet.
+- Fix missing teardown for session and module scoped fixtures when fixture teardown fails.
+  Fixes `#314 <https://github.com/pytest-dev/pytest-rerunfailures/issues/314>`_.
 
 
 16.1 (2025-10-10)

--- a/src/pytest_rerunfailures.py
+++ b/src/pytest_rerunfailures.py
@@ -250,11 +250,11 @@ def _remove_failed_setup_state_from_session(item):
     """
     Clean up setup state.
 
-    Note: remove all failures from every node in _setupstate stack
-          and clean the stack itself
+    Note: remove only the current item, not higher-scoped items
     """
     setup_state = item.session._setupstate
-    setup_state.stack = {}
+    if item in setup_state.stack:
+        del setup_state.stack[item]
 
 
 def _get_rerun_filter_regex(item, regex_name):


### PR DESCRIPTION
## PR Summary
When a fixture's teardown raised an exception and reruns were enabled, session and module scoped fixture teardowns were never executed. The cleanup logic was clearing the entire setup state stack instead of just removing the failed test item, which inadvertently removed the finalizers for higher-scoped fixtures. This PR fixes that by only removing the current test item from the stack.

Fixes #314.