### PR TITLE
feat: add --reruns-mode option to sum marker and global reruns (#321)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,14 @@ Changelog
 16.3 (unreleased)
 -----------------
 
-- Nothing changed yet.
+Features
+++++++++
+
+- Add ``--reruns-mode`` option (``strict`` or ``append``). With ``append``,
+  marker reruns and the global ``--reruns`` / ``reruns`` ini setting are summed
+  instead of the marker taking strict priority. Default is ``strict`` so
+  existing behaviour is unchanged.
+  Fixes `#321 <https://github.com/pytest-dev/pytest-rerunfailures/issues/321>`_.
 
 
 16.2 (2026-05-13)

--- a/README.rst
+++ b/README.rst
@@ -208,6 +208,18 @@ of re-runs specified in test markers, pass ``--force-reruns``:
 
    $ pytest --force-reruns 5
 
+Rerun mode
+----------
+
+By default the marker count takes strict priority over the global ``--reruns``
+setting. To make them additive instead, pass ``--reruns-mode=append``. With
+``append``, a test decorated with ``@pytest.mark.flaky(reruns=2)`` run with
+``--reruns 4`` will be re-run up to ``2 + 4 = 6`` times:
+
+.. code-block:: bash
+
+   $ pytest --reruns 4 --reruns-mode append
+
 Output
 ------
 
@@ -260,7 +272,8 @@ which one takes priority?
 * Last priority is the ``pyproject.toml`` (or ``pytest.ini``) file setting, like ``reruns = 3``
 
 Additionally, all three can be overridden by passing ``--force-reruns`` argument
-on the command line.
+on the command line. Passing ``--reruns-mode=append`` makes the marker count and
+the global ``--reruns`` / ``reruns`` ini setting additive instead of strict.
 
 .. END-PRIORITY
 

--- a/README.rst
+++ b/README.rst
@@ -219,7 +219,7 @@ setting. To make them additive instead, pass ``--reruns-mode=append``. With
 .. code-block:: bash
 
    $ pytest --reruns 4 --reruns-mode append
-   
+
 Show tracebacks for retried failures
 ------------------------------------
 

--- a/src/pytest_rerunfailures.py
+++ b/src/pytest_rerunfailures.py
@@ -94,6 +94,18 @@ def pytest_addoption(parser):
         "of regexes to match",
     )
     group._addoption(
+        "--reruns-mode",
+        action="store",
+        dest="reruns_mode",
+        type=str,
+        choices=("strict", "append"),
+        default="strict",
+        help="How to combine marker reruns with the global --reruns/reruns "
+        "ini setting. 'strict' (default) gives the marker priority over the "
+        "global setting. 'append' sums the marker and global counts so the "
+        "two are additive.",
+    )
+    group._addoption(
         "--fail-on-flaky",
         action="store_true",
         dest="fail_on_flaky",
@@ -119,6 +131,17 @@ def _get_marker(item):
     return item.get_closest_marker("flaky")
 
 
+def _get_global_reruns(item):
+    reruns = item.session.config.getvalue("reruns")
+    if reruns is not None:
+        return reruns
+
+    reruns = None
+    with suppress(TypeError, ValueError):
+        reruns = int(item.session.config.getini("reruns"))
+    return reruns
+
+
 def get_reruns_count(item):
     reruns = item.session.config.getvalue("force_reruns")
     if reruns is not None:
@@ -129,21 +152,20 @@ def get_reruns_count(item):
     if rerun_marker is not None:
         if "reruns" in rerun_marker.kwargs:
             # check for keyword arguments
-            return rerun_marker.kwargs["reruns"]
+            marker_reruns = rerun_marker.kwargs["reruns"]
         elif len(rerun_marker.args) > 0:
             # check for arguments
-            return rerun_marker.args[0]
+            marker_reruns = rerun_marker.args[0]
         else:
-            return 1
+            marker_reruns = 1
 
-    reruns = item.session.config.getvalue("reruns")
-    if reruns is not None:
-        return reruns
+        if item.session.config.getvalue("reruns_mode") == "append":
+            global_reruns = _get_global_reruns(item)
+            if global_reruns is not None:
+                return marker_reruns + global_reruns
+        return marker_reruns
 
-    with suppress(TypeError, ValueError):
-        reruns = int(item.session.config.getini("reruns"))
-
-    return reruns
+    return _get_global_reruns(item)
 
 
 def get_reruns_delay(item):

--- a/tests/test_pytest_rerunfailures.py
+++ b/tests/test_pytest_rerunfailures.py
@@ -1431,3 +1431,57 @@ def test_force_reruns(testdir, mark_params):
 
     result = testdir.runpytest("--force-reruns", "3")
     assert_outcomes(result, passed=0, failed=1, rerun=3)
+
+
+def test_reruns_mode_append_sums_marker_and_cli(testdir):
+    testdir.makepyfile(
+        """
+        import pytest
+
+        @pytest.mark.flaky(reruns=2)
+        def test_fail():
+            assert False
+    """
+    )
+
+    result = testdir.runpytest("--reruns", "4", "--reruns-mode", "append")
+    assert_outcomes(result, passed=0, failed=1, rerun=6)
+
+
+def test_reruns_mode_default_is_strict(testdir):
+    testdir.makepyfile(
+        """
+        import pytest
+
+        @pytest.mark.flaky(reruns=2)
+        def test_fail():
+            assert False
+    """
+    )
+
+    result = testdir.runpytest("--reruns", "4")
+    assert_outcomes(result, passed=0, failed=1, rerun=2)
+
+
+def test_reruns_mode_append_without_marker_uses_global(testdir):
+    testdir.makepyfile(
+        """
+        def test_fail():
+            assert False
+    """
+    )
+
+    result = testdir.runpytest("--reruns", "3", "--reruns-mode", "append")
+    assert_outcomes(result, passed=0, failed=1, rerun=3)
+
+
+def test_reruns_mode_invalid_choice_errors(testdir):
+    testdir.makepyfile(
+        """
+        def test_pass():
+            assert True
+    """
+    )
+
+    result = testdir.runpytest("--reruns-mode", "bogus")
+    assert result.ret != 0


### PR DESCRIPTION
Closes #321.

Adds `--reruns-mode=strict|append`. `strict` keeps the existing priority (marker overrides global). `append` sums the marker count and the global `--reruns` / `reruns` ini setting, so `@pytest.mark.flaky(reruns=2)` run with `--reruns 4` re-runs up to 6 times. Per @icemac in #321 ("I like the idea and I'd prefer the `--reruns-mode=append` vs. `strict` implementation of the option").