### PR TITLE
chore: drop redundant `pyupgrade` by Ruff `UP`, extend ruff config, drop setup.py

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,9 +4,8 @@ repos:
       rev: v0.14.0
       hooks:
         - id: ruff-format
-          args: ["--preview"]
         - id: ruff-check
-          args: ["--fix", "--exit-non-zero-on-fix"]
+          args: ["--exit-non-zero-on-fix"]
     - repo: https://github.com/pre-commit/pre-commit-hooks
       rev: v6.0.0
       hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,8 +5,8 @@ repos:
       hooks:
         - id: ruff-format
           args: ["--preview"]
-        - id: ruff
-          args: ["--exit-non-zero-on-fix"]
+        - id: ruff-check
+          args: ["--fix", "--exit-non-zero-on-fix"]
     - repo: https://github.com/pre-commit/pre-commit-hooks
       rev: v6.0.0
       hooks:
@@ -15,11 +15,6 @@ repos:
         - id: check-yaml
         - id: debug-statements
           language_version: python3
-    - repo: https://github.com/asottile/pyupgrade
-      rev: v3.21.2
-      hooks:
-        - id: pyupgrade
-          args: [--py310-plus]
     - repo: https://github.com/sphinx-contrib/sphinx-lint
       rev: v1.0.0
       hooks:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,3 @@
-include *.py
 include *.rst
 include *.toml
 include LICENSE

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 build-backend = "setuptools.build_meta"
 requires = [
-  "setuptools>=40",
+  "setuptools>=61",
 ]
 
 [project]
@@ -51,7 +51,9 @@ entry-points.pytest11.rerunfailures = "pytest_rerunfailures"
 readme = { file = [ "HEADER.rst", "README.rst", "CHANGES.rst" ] }
 
 [tool.ruff]
+target-version = "py310"
 fix = true
+format.preview = true
 lint.select = [
   "E",  # https://pypi.org/project/pyflakes/
   "F",  # https://pypi.org/project/pyflakes/

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,0 @@
-#!/usr/bin/env python
-from setuptools import setup
-
-setup()


### PR DESCRIPTION
This pull request updates the project's configuration and setup files to modernize tooling and streamline the build process. The most important changes include updating dependencies for better compatibility, refining pre-commit hooks, and cleaning up obsolete files and configuration.

**Build system and dependency updates:**

* Updated the minimum required version of `setuptools` in `pyproject.toml` from 40 to 61 to ensure compatibility with newer Python packaging standards.
* Set the `target-version` for Ruff to Python 3.10 and enabled `format.preview` in `pyproject.toml` to align linting and formatting with current Python versions.

**Pre-commit configuration improvements:**

* Replaced the `ruff` hook with `ruff-check` and enabled auto-fixing in `.pre-commit-config.yaml` for better code quality enforcement.
* Removed the `pyupgrade` pre-commit hook, as it is no longer needed, reducing unnecessary checks.

**Project cleanup:**

* Removed the `setup.py` file, as the project now relies on `pyproject.toml` for builds, following modern Python packaging practices.
* Stopped including all `.py` files in the source distribution by removing the relevant line from `MANIFEST.in`, likely to avoid packaging unnecessary files.

---

- Remove stub setup.py — all metadata in pyproject.toml; bump setuptools>=40→>=61 for src-layout auto-discovery
- Add ruff target-version="py310" (matches requires-python) and format.preview=true (matches pre-commit --preview)
- Update pre-commit: ruff→ruff-check with --fix, drop pyupgrade (UP ruleset in ruff covers it)
- Drop MANIFEST.in `include *.py` — no .py files at root after setup.py removal