### PR TITLE
fix: prevent rerun when teardown error matches --rerun-except

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,7 +12,7 @@ Bug fixes
   was considered, so a ``--rerun-except``-matching error raised during
   teardown was ignored and the test was rerun anyway.
   Fixes `#270 <https://github.com/pytest-dev/pytest-rerunfailures/issues/270>`_.
-  
+
 Features
 ++++++++
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,14 @@ Changelog
 16.5 (unreleased)
 -----------------
 
-- Nothing changed yet.
+Bug fixes
++++++++++
+
+- Prevent a rerun when a fixture teardown raises an error matching
+  ``--rerun-except``. Previously only the error from the current test stage
+  was considered, so a ``--rerun-except``-matching error raised during
+  teardown was ignored and the test was rerun anyway.
+  Fixes `#270 <https://github.com/pytest-dev/pytest-rerunfailures/issues/270>`_.
 
 
 16.4 (2026-07-01)

--- a/src/pytest_rerunfailures.py
+++ b/src/pytest_rerunfailures.py
@@ -500,7 +500,7 @@ def _should_hard_fail_on_error(item, report, excinfo):
 
 def _should_not_rerun(item, report, reruns):
     xfail = hasattr(report, "wasxfail")
-    is_terminal_error = item._terminal_errors[report.when]
+    is_terminal_error = any(item._terminal_errors.values())
     condition = get_reruns_condition(item)
     has_failed_subtests = (
         report.when == "call" and _get_num_failed_subtests(item, report) > 0

--- a/tests/test_pytest_rerunfailures.py
+++ b/tests/test_pytest_rerunfailures.py
@@ -855,6 +855,26 @@ def test_rerun_except_passes_setup_errors(testdir):
     assert_outcomes(result, passed=0, error=1, rerun=num_reruns)
 
 
+def test_rerun_except_teardown_error_prevents_rerun(testdir):
+    """Teardown errors covered by --rerun-except must prevent reruns."""
+    testdir.makepyfile(
+        """
+        import pytest
+
+        @pytest.fixture()
+        def broken_fixture():
+            yield
+            raise ValueError("teardown error")
+
+        def test_fail_in_fixture(broken_fixture):
+            assert False
+    """
+    )
+
+    result = testdir.runpytest("--reruns", "1", "--rerun-except", "ValueError")
+    assert_outcomes(result, passed=0, failed=1, error=1, rerun=0)
+
+
 @pytest.mark.parametrize(
     "condition, expected_reruns",
     [


### PR DESCRIPTION
Fixes #270

When --rerun-except is used and a teardown failure matches the excluded error, the test was still rerun because only the current report's stage was checked for terminal errors. Now all stages of the current execution are considered, so a terminal teardown error prevents reruns as expected.