### PR TITLE
Create a fresh test class instance for each rerun

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,12 @@ Bug fixes
   teardown was ignored and the test was rerun anyway.
   Fixes `#270 <https://github.com/pytest-dev/pytest-rerunfailures/issues/270>`_.
 
+- Create a new test class instance for each rerun. Previously the instance of
+  the failed attempt was reused, so state stored on ``self`` leaked into the
+  rerun and broke test isolation. Fixtures cached at class scope or higher are
+  still not re-executed.
+  Fixes `#268 <https://github.com/pytest-dev/pytest-rerunfailures/issues/268>`_.
+
 Features
 ++++++++
 

--- a/src/pytest_rerunfailures.py
+++ b/src/pytest_rerunfailures.py
@@ -358,6 +358,24 @@ def _remove_cached_results_from_failed_fixtures(item):
                         fixture_def._finalizers.clear()
 
 
+def _discard_test_class_instance(item):
+    """
+    Drop the cached test class instance so the rerun gets a fresh one.
+
+    Note: pytest creates one instance per test item and caches it on the item,
+    so without this the rerun would reuse the instance -- and therefore any
+    state stored on ``self`` -- of the attempt that just failed.
+    """
+    if getattr(item, "_instance", None) is None:
+        # no instance is cached: not a test method, or pytest dropped it itself
+        return
+
+    # ``obj`` is the method bound to the cached instance, so it has to go too;
+    # both are recomputed lazily on next access.
+    del item._instance
+    item._obj = None
+
+
 def _remove_failed_setup_state_from_session(item):
     """
     Clean up setup state.
@@ -947,6 +965,7 @@ def pytest_runtest_protocol(item, nextitem):
                 # cleanin item's cashed results from any level of setups
                 _remove_cached_results_from_failed_fixtures(item)
                 _remove_failed_setup_state_from_session(item)
+                _discard_test_class_instance(item)
                 _remove_failed_subtests_from_report(item, report)
                 _remove_failed_subtest_reports_from_stats(item)
 

--- a/tests/test_pytest_rerunfailures.py
+++ b/tests/test_pytest_rerunfailures.py
@@ -731,6 +731,75 @@ def test_rerun_on_session_fixture_with_reruns(testdir):
     assert_outcomes(result, passed=2, rerun=1)
 
 
+def test_rerun_recreates_test_class_instance(testdir):
+    """
+    Case: state stored on ``self`` by a failed attempt must not leak into the
+    rerun, i.e. every attempt gets a fresh test class instance
+    """
+    testdir.makepyfile(
+        """
+        import pytest
+
+        attempts = 0
+
+        class TestFoo(object):
+            @pytest.fixture(autouse=True)
+            def counting_fixture(self):
+                assert not hasattr(self, 'seen_by_fixture')
+                self.seen_by_fixture = True
+
+            @pytest.mark.flaky(reruns=2)
+            def test_fresh_instance(self):
+                global attempts
+                attempts += 1
+                assert not hasattr(self, 'seen_by_test')
+                self.seen_by_test = True
+                assert attempts == 3"""
+    )
+    result = testdir.runpytest()
+    assert_outcomes(result, passed=1, rerun=2)
+
+
+def test_rerun_recreates_instance_without_re_executing_scoped_fixtures(testdir):
+    """
+    Case: recreating the test class instance for a rerun must not invalidate
+    fixtures cached at a higher scope than function
+    """
+    testdir.makepyfile(
+        """
+        import pytest
+
+        attempts = 0
+        executions = {'session': 0, 'module': 0, 'class': 0}
+
+        @pytest.fixture(scope='session')
+        def session_fixture():
+            executions['session'] += 1
+
+        @pytest.fixture(scope='module')
+        def module_fixture():
+            executions['module'] += 1
+
+        @pytest.fixture(scope='class')
+        def class_fixture():
+            executions['class'] += 1
+
+        class TestFoo(object):
+            @pytest.mark.flaky(reruns=2)
+            def test_fresh_instance(
+                self, session_fixture, module_fixture, class_fixture
+            ):
+                global attempts
+                attempts += 1
+                assert executions == {'session': 1, 'module': 1, 'class': 1}
+                assert not hasattr(self, 'seen_by_test')
+                self.seen_by_test = True
+                assert attempts == 3"""
+    )
+    result = testdir.runpytest()
+    assert_outcomes(result, passed=1, rerun=2)
+
+
 def test_execution_count_exposed(testdir):
     testdir.makepyfile("def test_pass(): assert True")
     testdir.makeconftest(


### PR DESCRIPTION
pytest gives every test item its own instance of the test class, and caches it on
the item. The rerun loop reuses the same item, so a rerun also reuses the instance
of the attempt that just failed: state written to `self` (by the test itself or by
a class-defined fixture) survives into the next attempt, which breaks the per-test
isolation pytest otherwise guarantees. This changed with pytest 7.0; with pytest 6.x
each attempt did get a fresh instance.

Reproducer (from #268):

```python
import pytest

class TestExample:
    @property
    def counter(self):
        self.__dict__.setdefault('_counter', 0)
        self._counter += 1
        return self._counter

    @pytest.fixture(autouse=True)
    def some_fixture(self):
        print('SETUP', self.counter)
        yield
        print('TEARDOWN', self.counter)

    @pytest.mark.flaky(reruns=5)
    def test_something(self, param=[]):
        print('TEST', self.counter)
        param.append(0)
        assert len(param) > 2
```

Before:

```
SETUP 1
TEST 2
TEARDOWN 3
RSETUP 4
TEST 5
TEARDOWN 6
RSETUP 7
TEST 8
TEARDOWN 9
.
```

After:

```
SETUP 1
TEST 2
TEARDOWN 3
RSETUP 1
TEST 2
TEARDOWN 3
RSETUP 1
TEST 2
TEARDOWN 3
.
```

## The fix

`_discard_test_class_instance()` drops the item's cached `_instance` and the method
bound to it, as part of the cleanup that already runs just before a rerun is
triggered (after the failed attempt's teardown has completed). pytest recomputes
both lazily on next access via `Function._getinstance()`, which is exactly the path
used for a normal fresh test item — so no plugin-side reimplementation of
instantiation is needed. Doing it here rather than in a `pytest_runtest_setup` hook
keeps it next to the other per-rerun cleanup and means it only ever runs when this
plugin has actually decided to rerun.

Deliberately unchanged: nothing touches `FixtureDef.cached_result`, so fixtures
cached at class, module, package or session scope are still not re-executed on a
rerun. That is what `_remove_cached_results_from_failed_fixtures()` is careful about
and what `test_rerun_on_module_fixture_with_reruns` /
`test_rerun_on_session_fixture_with_reruns` pin — the second new test below pins it
again for this code path specifically, since "recreate the instance" is easy to get
wrong by invalidating fixtures along with it.

The guard returns early when no instance is cached, so plain (non-method) test
functions are unaffected, and `unittest.TestCase` items are too — pytest's own
`TestCaseFunction.teardown()` already drops `_instance`/`_obj` itself, and the guard
avoids eagerly constructing a throwaway `TestCase` just to discard it.

## Tests

Two tests in `tests/test_pytest_rerunfailures.py`:

- `test_rerun_recreates_test_class_instance` — state set on `self` by the test and by
  an autouse fixture must not be visible on the next attempt.
- `test_rerun_recreates_instance_without_re_executing_scoped_fixtures` — same, plus an
  assertion that the session-, module- and class-scoped fixtures each ran exactly once
  across all three attempts.

Before the fix (source change reverted, tests present):

```
$ pytest tests/test_pytest_rerunfailures.py -k recreate
FAILED tests/test_pytest_rerunfailures.py::test_rerun_recreates_test_class_instance
FAILED tests/test_pytest_rerunfailures.py::test_rerun_recreates_instance_without_re_executing_scoped_fixtures
2 failed, 147 deselected in 0.18s
```

with the inner failure being

```
>       assert not hasattr(self, 'seen_by_test')
E       AssertionError: assert not True
```

After:

```
$ pytest tests/test_pytest_rerunfailures.py -k recreate -v
tests/test_pytest_rerunfailures.py::test_rerun_recreates_test_class_instance PASSED
tests/test_pytest_rerunfailures.py::test_rerun_recreates_instance_without_re_executing_scoped_fixtures PASSED
2 passed, 147 deselected in 0.19s
```

Full suite, Python 3.13, run against every pytest version in the tox matrix
(baseline on master is 147 passed; the two skips on pytest < 9 are the subtests tests):

| pytest | result |
| --- | --- |
| 8.2.\* | 147 passed, 2 skipped |
| 8.3.\* | 147 passed, 2 skipped |
| 8.4.\* | 147 passed, 2 skipped |
| 9.0.\* | 149 passed |
| 9.1.\* | 149 passed |
| main   | 149 passed |

`pre-commit run --all-files` passes.

Fixes #268.
