### PR TITLE
Fix only_rerun marker precedence test

### DIFF
--- a/tests/test_pytest_rerunfailures.py
+++ b/tests/test_pytest_rerunfailures.py
@@ -1346,7 +1346,7 @@ def test_only_rerun_flag_in_flaky_marker(
     args = []
     if cli_only_rerun:
         args.extend(["--only-rerun", cli_only_rerun])
-    result = testdir.runpytest()
+    result = testdir.runpytest(*args)
     num_reruns = 1 if should_rerun else 0
     assert_outcomes(result, passed=0, failed=1, rerun=num_reruns)
 


### PR DESCRIPTION
`test_only_rerun_flag_in_flaky_marker` builds CLI arguments but doesn't pass them to `runpytest()`. This means its marker-vs-CLI cases never exercise the CLI option.

Pass the arguments to `runpytest()` so the test verifies that marker-level `only_rerun` takes precedence over the CLI value.

To confirm the gap, I temporarily reversed the precedence. The original test still passed, while the corrected test failed as expected.