### PR TITLE
Test rerun-except for setup errors

### DIFF
--- a/tests/test_pytest_rerunfailures.py
+++ b/tests/test_pytest_rerunfailures.py
@@ -1232,6 +1232,28 @@ def test_rerun_except_passes_setup_errors(testdir):
     assert_outcomes(result, passed=0, error=1, rerun=num_reruns)
 
 
+@pytest.mark.parametrize(
+    "rerun_except, expected_reruns",
+    [("ValueError", 0), ("TypeError", 1)],
+)
+def test_rerun_except_setup_error(testdir, rerun_except, expected_reruns):
+    testdir.makepyfile(
+        """
+        import pytest
+
+        @pytest.fixture()
+        def fixture_setup_fails():
+            raise ValueError("setup error")
+
+        def test_will_not_run(fixture_setup_fails):
+            pass
+        """
+    )
+
+    result = testdir.runpytest("--reruns", "1", "--rerun-except", rerun_except)
+    assert_outcomes(result, passed=0, error=1, rerun=expected_reruns)
+
+
 def test_rerun_except_teardown_error_prevents_rerun(testdir):
     """Teardown errors covered by --rerun-except must prevent reruns."""
     testdir.makepyfile(


### PR DESCRIPTION
This PR adds regression coverage for `--rerun-except` when an exception is raised during fixture setup.

Existing tests do not cover matching and non-matching `--rerun-except` filters for exceptions raised during setup.

The test covers both sides of the behavior:
* matching `ValueError` prevents the rerun,
* non-matching `TypeError` still allows one rerun.

No changelog entry has been included, as this change affects only tests and does not impact user behavior.