### PR TITLE
Restore higher-scoped teardown when a flaky condition is falsy

### DIFF
--- a/changes/351.bugfix.rst
+++ b/changes/351.bugfix.rst
@@ -1,0 +1,1 @@
+Restore module, class, and session scoped fixture teardown when a ``flaky`` marker condition is falsy.

--- a/src/pytest_rerunfailures.py
+++ b/src/pytest_rerunfailures.py
@@ -887,12 +887,14 @@ def pytest_runtest_teardown(item, nextitem):
         return
 
     # Only remove non-function level actions from the stack if the test is to be re-run
-    # Exceeding re-run limits, being free of failue statuses, and encountering
-    # allowable exceptions indicate that the test is not to be re-ran.
+    # Exceeding re-run limits, being free of failue statuses, encountering
+    # allowable exceptions, and a falsy flaky condition indicate that the test is
+    # not to be re-ran.
     if (
         item.execution_count <= reruns
         and any(_test_failed_statuses.values())
         and not any(item._terminal_errors.values())
+        and get_reruns_condition(item)
     ):
         # clean cached results from any level of setups
         _remove_cached_results_from_failed_fixtures(item)

--- a/tests/test_pytest_rerunfailures.py
+++ b/tests/test_pytest_rerunfailures.py
@@ -1338,6 +1338,99 @@ def test_reruns_with_string_condition_with_global_var(testdir):
     assert_outcomes(result, passed=0, failed=1, rerun=2)
 
 
+@pytest.mark.parametrize("scope", ["class", "module", "session"])
+def test_falsy_condition_preserves_higher_scope_teardown(testdir, scope):
+    testdir.makepyfile(
+        f"""
+        import pytest
+
+        @pytest.fixture(scope="{scope}", autouse=True)
+        def higher_scope_fixture():
+            yield
+            print("{scope} teardown")
+
+        class TestFlaky:
+            @pytest.mark.flaky(reruns=2, condition=False)
+            def test_fail(self):
+                assert False"""
+    )
+
+    result = testdir.runpytest("-s")
+    assert_outcomes(result, passed=0, failed=1, rerun=0)
+    result.stdout.fnmatch_lines(f"*{scope} teardown*")
+
+
+@pytest.mark.parametrize("condition", ["'os.getpid() == -1'"])
+def test_falsy_non_bool_condition_preserves_teardown(testdir, condition):
+    testdir.makepyfile(
+        f"""
+        import pytest
+
+        @pytest.fixture(scope="module", autouse=True)
+        def module_fixture():
+            yield
+            print("module teardown")
+
+        @pytest.mark.flaky(reruns=2, condition={condition})
+        def test_fail():
+            assert False"""
+    )
+
+    result = testdir.runpytest("-s")
+    assert_outcomes(result, passed=0, failed=1, rerun=0)
+    result.stdout.fnmatch_lines("*module teardown*")
+
+
+def test_falsy_condition_preserves_teardown_of_earlier_module(testdir):
+    testdir.makepyfile(
+        test_flaky_module="""
+        import pytest
+
+        @pytest.fixture(scope="module", autouse=True)
+        def flaky_module_fixture():
+            yield
+            print("flaky module teardown")
+
+        @pytest.mark.flaky(reruns=2, condition=False)
+        def test_fail():
+            assert False""",
+        test_later_module="""
+        def test_pass():
+            pass""",
+    )
+
+    result = testdir.runpytest("-s")
+    assert_outcomes(result, passed=1, failed=1, rerun=0)
+    result.stdout.fnmatch_lines("*flaky module teardown*")
+
+
+@pytest.mark.parametrize(
+    "marker, args",
+    [
+        ("@pytest.mark.flaky(reruns=2, condition=True)", []),
+        ("", ["--reruns", "2"]),
+    ],
+)
+def test_rerunnable_failure_tears_down_module_fixture_once(testdir, marker, args):
+    testdir.makepyfile(
+        f"""
+        import pytest
+
+        @pytest.fixture(scope="module", autouse=True)
+        def module_fixture():
+            yield
+            print("module teardown")
+
+        {marker}
+        def test_fail():
+            assert False"""
+    )
+
+    result = testdir.runpytest("-s", *args)
+    assert_outcomes(result, passed=0, failed=1, rerun=2)
+    assert result.stdout.str().count("module teardown") == 1
+
+
 @pytest.mark.parametrize(
     "marker_only_rerun,cli_only_rerun,should_rerun",
     [


### PR DESCRIPTION
`pytest_runtest_teardown` decides whether to suspend module, class and session finalizers using a gate that checks the rerun limit, the failure statuses and terminal errors. It never checks the `flaky` marker's `condition`, which `_should_not_rerun` does check.

So with a falsy condition on a failing test, teardown suspends the higher-scoped finalizers, the protocol then declines to rerun, `_restore_suspended_finalizers` is never reached, and that fixture's teardown never runs again for the rest of the session:

```python
@pytest.fixture(scope="module", autouse=True)
def module_fixture():
    yield
    print("module teardown")

@pytest.mark.flaky(reruns=2, condition=False)
def test_fail():
    assert False
```

`module teardown` is not printed. With `condition=True`, or with no marker at all, it is. The damage is not local either, since `suspended_finalizers` is a module-level global: run that file alongside another and the first module's fixture stays un-torn-down past the end of its own module.

Adding the missing term to the gate is the whole fix. I also updated the comment above it, which enumerated the terms and was already one short.

Tests cover class, module and session scope, a string condition that evaluates falsy, and the cross-module case. Two are guards rather than reproductions: `condition=True` still reruns and still tears down exactly once, and a plain `--reruns` failure with no marker is unaffected.

Scope, so you do not have to ask. This fixes the `condition` gap only. Two related leaks are pre-existing and untouched. A terminal error raised in the *teardown* phase still leaks, because `_terminal_errors["teardown"]` is written from `pytest_runtest_makereport` after the teardown hook has already suspended, so it needs a hookwrapper rather than another gate term. And a call-phase failure consisting solely of failed subtests tears higher-scoped fixtures down prematurely on every attempt, which is the same drift in the opposite direction. Happy to take either as a follow-up if you want them.
