### PR TITLE
Fix subtest rerun reporting with xdist

### DIFF
--- a/changes/350.bugfix.rst
+++ b/changes/350.bugfix.rst
@@ -1,0 +1,1 @@
+Prevent superseded built-in subtest failures from remaining in the final test result when rerunning tests with pytest-xdist.

--- a/src/pytest_rerunfailures.py
+++ b/src/pytest_rerunfailures.py
@@ -410,10 +410,12 @@ def _remove_failed_subtests_from_report(item, report):
         del failed_subtests[report.nodeid]
 
 
-def _remove_failed_subtest_reports_from_stats(item):
+def _remove_failed_subtest_reports_from_stats(
+    config, session, nodeid, worker_id=None, item_index=None
+):
     """
-    Remove already-logged SubtestReports for this item from the terminal reporter's
-    stats buckets.
+    Remove already-logged SubtestReports for a superseded test attempt from the
+    terminal reporter's stats buckets.
 
     SubtestReports are logged immediately during runtestprotocol (independent of
     log=False), so when a rerun is triggered they must be retroactively removed
@@ -429,13 +431,13 @@ def _remove_failed_subtest_reports_from_stats(item):
     if SubtestReport is None:
         return
 
-    tr = item.config.pluginmanager.get_plugin("terminalreporter")
+    tr = config.pluginmanager.get_plugin("terminalreporter")
     if tr is None:
         return
 
     def _remove_subtest_reports(key):
         """
-        Remove SubtestReports for item.nodeid from tr.stats[key].
+        Remove matching SubtestReports from tr.stats[key].
 
         Returns the number of removed reports, and deletes the key entirely when
         the list becomes empty, because some code just checks the presence of
@@ -444,11 +446,21 @@ def _remove_failed_subtest_reports_from_stats(item):
         if key not in tr.stats:
             return 0
 
+        def is_matching_subtest_report(report):
+            if not isinstance(report, SubtestReport) or report.nodeid != nodeid:
+                return False
+            if (
+                worker_id is not None
+                and getattr(report, "worker_id", None) != worker_id
+            ):
+                return False
+            return (
+                item_index is None or getattr(report, "item_index", None) == item_index
+            )
+
         num_items_before = len(tr.stats[key])
         tr.stats[key] = [
-            r
-            for r in tr.stats[key]
-            if not isinstance(r, SubtestReport) or r.nodeid != item.nodeid
+            report for report in tr.stats[key] if not is_matching_subtest_report(report)
         ]
         num_items_removed = num_items_before - len(tr.stats[key])
 
@@ -461,7 +473,7 @@ def _remove_failed_subtest_reports_from_stats(item):
     if failed_removed > 0:
         # Decrement session.testsfailed which was incremented when the
         # SubtestReport was originally logged via pytest_runtest_logreport.
-        item.session.testsfailed = max(0, item.session.testsfailed - failed_removed)
+        session.testsfailed = max(0, session.testsfailed - failed_removed)
 
     # When a test is rerun, subtests that already passed on the first attempt
     # will run again and produce a second SUBPASSED report. Remove the first
@@ -589,6 +601,28 @@ def pytest_configure(config):
 
 
 class XDistHooks:
+    def pytest_sessionstart(self, session):
+        self.session = session
+
+    def pytest_runtest_logreport(self, report):
+        """Clean up subtest reports superseded by a worker rerun."""
+        worker_id = getattr(report, "worker_id", None)
+        item_index = getattr(report, "item_index", None)
+        # xdist adds worker_id and item_index when forwarding a report to the
+        # controller. Together they distinguish every collected test item.
+        if (
+            report.outcome == "rerun"
+            and worker_id is not None
+            and item_index is not None
+        ):
+            _remove_failed_subtest_reports_from_stats(
+                self.session.config,
+                self.session,
+                report.nodeid,
+                worker_id=worker_id,
+                item_index=item_index,
+            )
+
     def pytest_configure_node(self, node):
         """Configure xdist hook for node sock_port."""
         node.workerinput["sock_port"] = node.config.failures_db.sock_port
@@ -994,7 +1028,9 @@ def pytest_runtest_protocol(item, nextitem):
                 _remove_failed_setup_state_from_session(item)
                 _discard_test_class_instance(item)
                 _remove_failed_subtests_from_report(item, report)
-                _remove_failed_subtest_reports_from_stats(item)
+                _remove_failed_subtest_reports_from_stats(
+                    item.config, item.session, item.nodeid
+                )
 
                 rerun_triggered = True
 

--- a/tests/test_pytest_rerunfailures.py
+++ b/tests/test_pytest_rerunfailures.py
@@ -2161,6 +2161,96 @@ def test_too_many_failing_subtests_are_failures(testdir):
     assert_outcomes(result, passed=0, failed=2, rerun=1)
 
 
+@pytest.mark.skipif(
+    not has_subtests or not has_xdist,
+    reason="Requires pytest 9.0 or newer and xdist",
+)
+def test_failing_subtests_are_rerun_with_xdist(testdir):
+    testdir.makepyfile(
+        f"""
+        import pytest
+
+        def test_subtests(subtests):
+            with subtests.test("Fails on first attempt"):
+                {indent(temporary_failure(), "    ")}
+    """
+    )
+
+    result = testdir.runpytest("-p", "xdist", "-n", "1", "--reruns", "1")
+    assert result.ret == pytest.ExitCode.OK
+    assert_outcomes(result, passed=1, failed=0, rerun=1)
+
+
+@pytest.mark.skipif(
+    not has_subtests or not has_xdist,
+    reason="Requires pytest 9.0 or newer and xdist",
+)
+def test_too_many_failing_subtests_are_failures_with_xdist(testdir):
+    testdir.makepyfile(
+        """
+        import pytest
+
+        def test_subtests(subtests):
+            with subtests.test("Always fails"):
+                assert False
+    """
+    )
+
+    result = testdir.runpytest("-p", "xdist", "-n", "1", "--reruns", "1")
+    assert result.ret == pytest.ExitCode.TESTS_FAILED
+    assert_outcomes(result, passed=0, failed=2, rerun=1)
+
+
+@pytest.mark.skipif(
+    not has_subtests or not has_xdist,
+    reason="Requires pytest 9.0 or newer and xdist",
+)
+def test_xdist_subtest_cleanup_is_scoped_to_worker(testdir):
+    testdir.makepyfile(
+        """
+        import pytest
+
+        def test_subtests(subtests):
+            with subtests.test("Always fails"):
+                assert False
+    """
+    )
+
+    result = testdir.runpytest("-p", "xdist", "-n", "2", "--dist=each", "--reruns", "1")
+    assert result.ret == pytest.ExitCode.TESTS_FAILED
+    assert_outcomes(result, passed=0, failed=4, rerun=2)
+
+
+@pytest.mark.skipif(
+    not has_subtests or not has_xdist,
+    reason="Requires pytest 9.0 or newer and xdist",
+)
+def test_xdist_subtest_cleanup_is_scoped_to_item_index(testdir):
+    test_file = testdir.makepyfile(
+        """
+        import pytest
+
+        def test_subtests(subtests):
+            with subtests.test("Always fails"):
+                assert False
+    """
+    )
+
+    result = testdir.runpytest(
+        "-p",
+        "xdist",
+        "-n",
+        "1",
+        "--keep-duplicates",
+        test_file,
+        test_file,
+        "--reruns",
+        "1",
+    )
+    assert result.ret == pytest.ExitCode.TESTS_FAILED
+    assert_outcomes(result, passed=0, failed=4, rerun=2)
+
+
 def test_max_suite_reruns_caps_flaky_marker_reruns(testdir):
     testdir.makepyfile(
         """


### PR DESCRIPTION
Fixes #350.

This fixes an issue where a built-in subtest that passes on rerun could still leave a stale failure under xdist, causing the session to fail.

The fix removes only failures from the superseded attempt, while preserving results from other workers and duplicate collected items.

Regression tests cover successful and exhausted reruns, cross-worker isolation, and duplicate collection under xdist.