### PR TITLE
Test with pytest-xdist on CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,6 +73,29 @@ jobs:
         run: |
           pytest
 
+  xdist:
+    # The xdist specific tests are skipped unless pytest-xdist is installed,
+    # so run the test suite once with it on the newest Python and pytest.
+    name: xdist:py-3.14:pytest-9.1
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.14"
+          allow-prereleases: true
+
+      - name: Install dependencies
+        run: |
+          python -m pip install -U pip
+          python -m pip install pytest==9.1.* pytest-xdist
+          python -m pip install -e .
+
+      - name: Tests
+        run: pytest
+
   platform:
     # Test devel setup on different platforms.
     name: Platform-${{ matrix.os }}

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ docs/_build/
 include/
 lib/
 pip-selfcheck.json
+uv.lock

--- a/tox.ini
+++ b/tox.ini
@@ -12,13 +12,14 @@ max-line-length = 88
 envlist =
     linting
     py{310,311,312,313,314,py3}-pytest{82,83,84,90,91,main}
+    py314-pytest91-xdist
     docs
 minversion = 4.0
 
 [testenv]
 commands = pytest tests/ {posargs}
 deps =
-    pytest-xdist
+    xdist: pytest-xdist
     pytest82: pytest==8.2.*
     pytest83: pytest==8.3.*
     pytest84: pytest==8.4.*


### PR DESCRIPTION
The xdist specific tests were skipped everywhere because pytest-xdist was never installed on CI. Adds a tox environment and CI job for the newest Python and pytest, and ignores the local `uv.lock`.

— _Comment created by Claude_