### PR TITLE
Fix set-output deprecation warnings

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Get pip cache dir
         id: pip-cache
         run: |
-          echo "::set-output name=dir::$(pip cache dir)"
+          echo "dir=$(pip cache dir)" >> "$GITHUB_OUTPUT"
 
       - name: Cache
         uses: actions/cache@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,16 +47,16 @@ jobs:
       - name: Get pip cache dir
         id: pip-cache
         run: |
-          echo "::set-output name=dir::$(pip cache dir)"
+          echo "dir=$(pip cache dir)" >> "$GITHUB_OUTPUT"
 
       - name: Cache
         uses: actions/cache@v6
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
           key:
-            ${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.pytest-version }}-v1-${{ hashFiles('**/pyproject.toml') }}
+            ${{ matrix.python-version }}-${{ matrix.pytest-version }}-v1-${{ hashFiles('**/pyproject.toml') }}
           restore-keys: |
-            ${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.pytest-version }}-v1-
+            ${{ matrix.python-version }}-${{ matrix.pytest-version }}-v1-
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
Each matrix job warned about the deprecated `set-output` command; write to `$GITHUB_OUTPUT` instead. `matrix.os` is gone from the test cache key because the `tests` job has no `os` dimension.

— _Comment created by Claude_