### PR TITLE
Restore higher-scoped teardown when a teardown error rules out a re-run

### DIFF
--- a/changes/356.bugfix.rst
+++ b/changes/356.bugfix.rst
@@ -1,0 +1,1 @@
+Restore module, class, and session scoped fixture teardown when an error raised during teardown rules out a re-run.

--- a/src/pytest_rerunfailures.py
+++ b/src/pytest_rerunfailures.py
@@ -13,9 +13,12 @@ from contextlib import suppress
 from typing import Any
 
 import pytest
-from _pytest.outcomes import fail
+from _pytest.outcomes import Exit, fail
 from _pytest.runner import runtestprotocol
 from packaging.version import parse as parse_version
+
+if sys.version_info < (3, 11):
+    from exceptiongroup import BaseExceptionGroup
 
 failed_subtests_key: Any
 SubtestReport: Any
@@ -534,10 +537,6 @@ def _should_hard_fail_on_error(item, report, excinfo):
     if report.outcome != "failed":
         return False
 
-    return _is_terminal_error(item, excinfo)
-
-
-def _is_terminal_error(item, excinfo):
     rerun_errors = _get_rerun_filter_regex(item, "only_rerun")
     rerun_except_errors = _get_rerun_filter_regex(item, "rerun_except")
 
@@ -902,21 +901,65 @@ def _is_rerun_path_excluded(item):
     )
 
 
-def _suspend_finalizers_for_rerun(item):
-    """Hold back the higher-scope finalizers if the test is going to be re-run.
+def _teardown_suspended_finalizers(item, call, report):
+    """Tear down the scopes held back for a re-run that will not happen.
 
-    Returns whether they were taken off the stack.
+    pytest_runtest_teardown takes the module, class and session finalizers off
+    the setup stack when it expects the test to be re-run. Whether the error a
+    teardown raised rules that re-run out is only known here, where the report
+    of the phase says how the error was classified, so put the finalizers back
+    and tear down whatever this item was the last user of.
+
+    Returns the report of the teardown phase.
     """
+    if not getattr(item, "_finalizers_suspended", False):
+        return report
+
+    item._finalizers_suspended = False
+    _restore_suspended_finalizers(item)
+
+    def teardown_higher_scopes():
+        try:
+            item.session._setupstate.teardown_exact(item._teardown_nextitem)
+        except (Exit, KeyboardInterrupt):
+            # A fixture that ends the session has to keep ending it.
+            raise
+        except BaseException as exc:
+            if call.excinfo is None:
+                raise
+            # Both errors come from the teardown of this item, so report them
+            # together, the way pytest reports several failing finalizers.
+            raise BaseExceptionGroup(
+                "errors during test teardown", [exc, call.excinfo.value]
+            ) from None
+
+    teardown_call = pytest.CallInfo.from_call(
+        teardown_higher_scopes, when="teardown", reraise=(Exit, KeyboardInterrupt)
+    )
+    if teardown_call.excinfo is None:
+        return report
+
+    # The report of the phase is already built, so the only way for the error
+    # above to reach the terminal is a report that replaces it.
+    return pytest.TestReport.from_item_and_call(item, teardown_call)
+
+
+def pytest_runtest_teardown(item, nextitem):
+    # pytest_runtest_makereport needs both of these to finish a teardown this
+    # hook left half done because it expected a re-run.
+    item._finalizers_suspended = False
+    item._teardown_nextitem = nextitem
+
     reruns = get_reruns_count(item)
     if reruns is None:
         # global setting is not specified, and this test is not marked with
         # flaky
-        return False
+        return
 
     if not hasattr(item, "execution_count"):
         # pytest_runtest_protocol hook of this plugin was not executed
         # -> teardown needs to be skipped as well
-        return False
+        return
 
     _test_failed_statuses = getattr(item, "_test_failed_statuses", {})
 
@@ -926,7 +969,7 @@ def _suspend_finalizers_for_rerun(item):
         and item.session.config.failures_db.get_suite_reruns() >= max_suite_reruns
     ):
         _restore_suspended_finalizers(item)
-        return False
+        return
 
     # Only remove non-function level actions from the stack if the test is to be re-run
     # Exceeding re-run limits, being free of failue statuses, encountering
@@ -948,47 +991,17 @@ def _suspend_finalizers_for_rerun(item):
                     if key not in suspended_finalizers:
                         suspended_finalizers[key] = item.session._setupstate.stack[key]
                     del item.session._setupstate.stack[key]
-        return True
-
-    # restore suspended finalizers
-    _restore_suspended_finalizers(item)
-    return False
-
-
-def _teardown_error_is_terminal(item, outcome):
-    """Report whether the teardown phase raised an error that stops re-runs."""
-    exc_info = outcome.excinfo
-    if exc_info is None:
-        return False
-
-    return _is_terminal_error(item, pytest.ExceptionInfo.from_exc_info(exc_info))
-
-
-@pytest.hookimpl(hookwrapper=True)
-def pytest_runtest_teardown(item, nextitem):
-    suspended = _suspend_finalizers_for_rerun(item)
-    outcome = yield
-
-    # The error a teardown raises is only classified once this hook has
-    # returned, so the decision above could not take it into account. A
-    # terminal one means there is no re-run to hold the finalizers back for,
-    # so put them back on the stack and tear down what this item was the last
-    # user of.
-    if suspended and _teardown_error_is_terminal(item, outcome):
+                    item._finalizers_suspended = True
+    else:
+        # restore suspended finalizers
         _restore_suspended_finalizers(item)
-        try:
-            item.session._setupstate.teardown_exact(nextitem)
-        except BaseException as exc:
-            # The error raised above is the one that rules out a re-run, so it
-            # has to stay the error of this phase. Chain this one onto it
-            # instead of replacing it, so both end up in the report.
-            outcome.excinfo[1].__context__ = exc
 
 
-@pytest.hookimpl(hookwrapper=True)
+# A wrapper rather than an old-style hookwrapper because it has to be able to
+# let an Exit or a KeyboardInterrupt out of _teardown_suspended_finalizers.
+@pytest.hookimpl(wrapper=True)
 def pytest_runtest_makereport(item, call):
-    outcome = yield
-    result = outcome.get_result()
+    result = yield
     if result.when == "setup":
         # clean failed statuses at the beginning of each test/rerun
         setattr(item, "_test_failed_statuses", {})
@@ -1002,6 +1015,11 @@ def pytest_runtest_makereport(item, call):
     item._terminal_errors[result.when] = _should_hard_fail_on_error(
         item, result, call.excinfo
     )
+
+    if result.when == "teardown" and item._terminal_errors["teardown"]:
+        result = _teardown_suspended_finalizers(item, call, result)
+
+    return result
 
 
 def pytest_runtest_protocol(item, nextitem):

--- a/src/pytest_rerunfailures.py
+++ b/src/pytest_rerunfailures.py
@@ -534,6 +534,10 @@ def _should_hard_fail_on_error(item, report, excinfo):
     if report.outcome != "failed":
         return False
 
+    return _is_terminal_error(item, excinfo)
+
+
+def _is_terminal_error(item, excinfo):
     rerun_errors = _get_rerun_filter_regex(item, "only_rerun")
     rerun_except_errors = _get_rerun_filter_regex(item, "rerun_except")
 
@@ -898,17 +902,21 @@ def _is_rerun_path_excluded(item):
     )
 
 
-def pytest_runtest_teardown(item, nextitem):
+def _suspend_finalizers_for_rerun(item):
+    """Hold back the higher-scope finalizers if the test is going to be re-run.
+
+    Returns whether they were taken off the stack.
+    """
     reruns = get_reruns_count(item)
     if reruns is None:
         # global setting is not specified, and this test is not marked with
         # flaky
-        return
+        return False
 
     if not hasattr(item, "execution_count"):
         # pytest_runtest_protocol hook of this plugin was not executed
         # -> teardown needs to be skipped as well
-        return
+        return False
 
     _test_failed_statuses = getattr(item, "_test_failed_statuses", {})
 
@@ -918,7 +926,7 @@ def pytest_runtest_teardown(item, nextitem):
         and item.session.config.failures_db.get_suite_reruns() >= max_suite_reruns
     ):
         _restore_suspended_finalizers(item)
-        return
+        return False
 
     # Only remove non-function level actions from the stack if the test is to be re-run
     # Exceeding re-run limits, being free of failue statuses, encountering
@@ -940,9 +948,41 @@ def pytest_runtest_teardown(item, nextitem):
                     if key not in suspended_finalizers:
                         suspended_finalizers[key] = item.session._setupstate.stack[key]
                     del item.session._setupstate.stack[key]
-    else:
-        # restore suspended finalizers
+        return True
+
+    # restore suspended finalizers
+    _restore_suspended_finalizers(item)
+    return False
+
+
+def _teardown_error_is_terminal(item, outcome):
+    """Report whether the teardown phase raised an error that stops re-runs."""
+    exc_info = outcome.excinfo
+    if exc_info is None:
+        return False
+
+    return _is_terminal_error(item, pytest.ExceptionInfo.from_exc_info(exc_info))
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_teardown(item, nextitem):
+    suspended = _suspend_finalizers_for_rerun(item)
+    outcome = yield
+
+    # The error a teardown raises is only classified once this hook has
+    # returned, so the decision above could not take it into account. A
+    # terminal one means there is no re-run to hold the finalizers back for,
+    # so put them back on the stack and tear down what this item was the last
+    # user of.
+    if suspended and _teardown_error_is_terminal(item, outcome):
         _restore_suspended_finalizers(item)
+        try:
+            item.session._setupstate.teardown_exact(nextitem)
+        except BaseException as exc:
+            # The error raised above is the one that rules out a re-run, so it
+            # has to stay the error of this phase. Chain this one onto it
+            # instead of replacing it, so both end up in the report.
+            outcome.excinfo[1].__context__ = exc
 
 
 @pytest.hookimpl(hookwrapper=True)

--- a/tests/test_pytest_rerunfailures.py
+++ b/tests/test_pytest_rerunfailures.py
@@ -1541,6 +1541,95 @@ def test_rerunnable_teardown_error_tears_down_module_fixture_once(testdir):
 
 
 @pytest.mark.parametrize(
+    "outcome,skipped,xfailed",
+    [("skip", 3, 0), ("xfail", 0, 3)],
+)
+def test_teardown_error_that_is_not_a_failure_does_not_stop_reruns(
+    testdir, outcome, skipped, xfailed
+):
+    testdir.makepyfile(
+        f"""
+        import pytest
+
+        @pytest.fixture(scope="module", autouse=True)
+        def module_fixture():
+            yield
+            print("module teardown")
+
+        @pytest.fixture
+        def not_failing_fixture():
+            yield
+            pytest.{outcome}("{outcome} in teardown")
+
+        @pytest.mark.flaky(reruns=2, only_rerun=["AssertionError"])
+        def test_fail(not_failing_fixture):
+            assert False"""
+    )
+
+    result = testdir.runpytest("-s")
+    assert_outcomes(
+        result, passed=0, skipped=skipped, xfailed=xfailed, failed=1, rerun=2
+    )
+    assert result.stdout.str().count("module teardown") == 1
+
+
+def test_terminal_teardown_error_lets_a_higher_scope_teardown_exit(testdir):
+    testdir.makepyfile(
+        test_flaky_module="""
+        import pytest
+
+        @pytest.fixture(scope="module", autouse=True)
+        def module_fixture():
+            yield
+            pytest.exit("exit from teardown")
+
+        @pytest.fixture
+        def broken_fixture():
+            yield
+            raise ValueError("teardown error")
+
+        @pytest.mark.flaky(reruns=2, rerun_except=["ValueError"])
+        def test_fail(broken_fixture):
+            assert False""",
+        test_later_module="""
+        def test_pass():
+            print("later module test")""",
+    )
+
+    result = testdir.runpytest("-s")
+    assert result.ret == pytest.ExitCode.INTERRUPTED
+    result.stdout.fnmatch_lines("*Exit: exit from teardown*")
+    assert "later module test" not in result.stdout.str()
+
+
+def test_terminal_teardown_error_reports_higher_scope_teardown_without_context(testdir):
+    testdir.makepyfile(
+        """
+        import pytest
+
+        @pytest.fixture(scope="module", autouse=True)
+        def module_fixture():
+            yield
+            raise RuntimeError("module teardown error")
+
+        @pytest.fixture
+        def broken_fixture():
+            yield
+            raise ValueError("teardown error") from None
+
+        @pytest.mark.flaky(reruns=2, rerun_except=["ValueError"])
+        def test_fail(broken_fixture):
+            assert False"""
+    )
+
+    result = testdir.runpytest()
+    assert_outcomes(result, passed=0, failed=1, error=1, rerun=0)
+    result.stdout.fnmatch_lines(
+        ["*RuntimeError: module teardown error*", "*ValueError: teardown error*"],
+    )
+
+
+@pytest.mark.parametrize(
     "marker_only_rerun,cli_only_rerun,should_rerun",
     [
         ("AssertionError", None, True),

--- a/tests/test_pytest_rerunfailures.py
+++ b/tests/test_pytest_rerunfailures.py
@@ -1431,6 +1431,115 @@ def test_rerunnable_failure_tears_down_module_fixture_once(testdir, marker, args
     assert result.stdout.str().count("module teardown") == 1
 
 
+@pytest.mark.parametrize("scope", ["class", "module", "session"])
+def test_terminal_teardown_error_preserves_higher_scope_teardown(testdir, scope):
+    testdir.makepyfile(
+        f"""
+        import pytest
+
+        @pytest.fixture(scope="{scope}", autouse=True)
+        def higher_scope_fixture():
+            yield
+            print("{scope} teardown")
+
+        @pytest.fixture
+        def broken_fixture():
+            yield
+            raise ValueError("teardown error")
+
+        class TestFlaky:
+            @pytest.mark.flaky(reruns=2, rerun_except=["ValueError"])
+            def test_fail(self, broken_fixture):
+                assert False"""
+    )
+
+    result = testdir.runpytest("-s")
+    assert_outcomes(result, passed=0, failed=1, error=1, rerun=0)
+    result.stdout.fnmatch_lines(f"*{scope} teardown*")
+
+
+def test_terminal_teardown_error_preserves_teardown_of_earlier_module(testdir):
+    testdir.makepyfile(
+        test_flaky_module="""
+        import pytest
+
+        @pytest.fixture(scope="module", autouse=True)
+        def flaky_module_fixture():
+            yield
+            print("flaky module teardown")
+
+        @pytest.fixture
+        def broken_fixture():
+            yield
+            raise ValueError("teardown error")
+
+        @pytest.mark.flaky(reruns=2, rerun_except=["ValueError"])
+        def test_fail(broken_fixture):
+            assert False""",
+        test_later_module="""
+        def test_pass():
+            print("later module test")""",
+    )
+
+    result = testdir.runpytest("-s")
+    assert_outcomes(result, passed=1, failed=1, error=1, rerun=0)
+    result.stdout.fnmatch_lines(
+        ["*flaky module teardown*", "*later module test*"],
+    )
+
+
+def test_terminal_teardown_error_reports_failing_higher_scope_teardown(testdir):
+    testdir.makepyfile(
+        """
+        import pytest
+
+        @pytest.fixture(scope="module", autouse=True)
+        def module_fixture():
+            yield
+            raise RuntimeError("module teardown error")
+
+        @pytest.fixture
+        def broken_fixture():
+            yield
+            raise ValueError("teardown error")
+
+        @pytest.mark.flaky(reruns=2, rerun_except=["ValueError"])
+        def test_fail(broken_fixture):
+            assert False"""
+    )
+
+    result = testdir.runpytest()
+    assert_outcomes(result, passed=0, failed=1, error=1, rerun=0)
+    result.stdout.fnmatch_lines(
+        ["*RuntimeError: module teardown error*", "*ValueError: teardown error*"],
+    )
+
+
+def test_rerunnable_teardown_error_tears_down_module_fixture_once(testdir):
+    testdir.makepyfile(
+        """
+        import pytest
+
+        @pytest.fixture(scope="module", autouse=True)
+        def module_fixture():
+            yield
+            print("module teardown")
+
+        @pytest.fixture
+        def broken_fixture():
+            yield
+            raise ValueError("teardown error")
+
+        @pytest.mark.flaky(reruns=2, only_rerun=["AssertionError", "ValueError"])
+        def test_fail(broken_fixture):
+            assert False"""
+    )
+
+    result = testdir.runpytest("-s")
+    assert_outcomes(result, passed=0, failed=1, error=3, rerun=2)
+    assert result.stdout.str().count("module teardown") == 1
+
+
 @pytest.mark.parametrize(
     "marker_only_rerun,cli_only_rerun,should_rerun",
     [


### PR DESCRIPTION
Follow-up to #351, the first of the two leaks I mentioned there.

`pytest_runtest_teardown` takes the module, class and session finalizers off the setup stack when it expects a re-run. Whether the error a teardown raised is terminal is only worked out afterwards, in `pytest_runtest_makereport`, so that decision cannot see it. When `--rerun-except` or `--only-rerun` classifies that error as one not to re-run on, the protocol then declines to re-run, `_restore_suspended_finalizers` is never reached, and the fixture's teardown never runs again for the rest of the session:

```python
@pytest.fixture(scope="module", autouse=True)
def module_fixture():
    yield
    print("module teardown")

@pytest.fixture
def broken_fixture():
    yield
    raise ValueError("teardown error")

@pytest.mark.flaky(reruns=2, rerun_except=["ValueError"])
def test_fail(broken_fixture):
    assert False
```

`module teardown` is not printed. As with #351 the damage is not local, since `suspended_finalizers` is a module-level global: run that file alongside another and the first module's fixture stays un-torn-down past the end of its own module.

Adding a term to the gate does not work here, because the error does not exist yet when the gate runs. So the hook becomes a wrapper. On the way in it decides exactly as before. On the way out it looks at the error the teardown phase actually raised, and if that error rules out a re-run it puts the finalizers back and calls `teardown_exact`. Running them there rather than just restoring them matters: a restore alone leaves a stale collector on the stack, and the next item's `SetupState.setup` asserts on that.

If a higher-scoped teardown then fails itself, its error is chained onto the one that got us there instead of replacing it. Replacing it would change what the re-run decision is made on, and the test would start re-running again.

Tests cover class, module and session scope, the cross-module case, and a higher-scoped teardown that fails while being run this way. Two are guards rather than reproductions: an error the filters do allow a re-run on still re-runs and still tears the module fixture down exactly once, and the plain `--reruns` paths are untouched.

The remaining leak, premature teardown when a call phase fails through subtests only, is a separate PR.
