### PR TITLE
Prevent negative reruns from skipping initial test execution

### DIFF
--- a/changes/359.bugfix.rst
+++ b/changes/359.bugfix.rst
@@ -1,0 +1,1 @@
+Ensure negative rerun counts do not skip the initial test execution.

--- a/src/pytest_rerunfailures.py
+++ b/src/pytest_rerunfailures.py
@@ -1089,7 +1089,8 @@ def pytest_runtest_protocol(item, nextitem):
     item.execution_count = db.get_test_failures(item.nodeid)
     db.set_test_reruns(item.nodeid, reruns)
 
-    if item.execution_count > reruns:
+    # A rerun count limits extra attempts, not the initial test execution.
+    if item.execution_count > reruns and item.execution_count > 0:
         return True
 
     need_to_run = True

--- a/tests/test_pytest_rerunfailures.py
+++ b/tests/test_pytest_rerunfailures.py
@@ -2370,6 +2370,54 @@ def test_force_reruns(testdir, mark_params):
     assert_outcomes(result, passed=0, failed=1, rerun=3)
 
 
+@pytest.mark.parametrize(
+    ("pytest_args", "ini", "marker"),
+    [
+        (("--reruns", "-1"), None, ""),
+        ((), "reruns = -1", ""),
+        (("--force-reruns", "-1"), None, ""),
+        ((), None, "@pytest.mark.flaky(reruns=-1)"),
+    ],
+)
+def test_negative_reruns_does_not_skip_initial_execution(
+    testdir, pytest_args, ini, marker
+):
+    if ini:
+        testdir.makeini(f"[pytest]\n{ini}")
+    testdir.makepyfile(
+        f"""
+        import pytest
+
+        {marker}
+        def test_fail():
+            assert False
+        """
+    )
+
+    result = testdir.runpytest(*pytest_args)
+
+    assert result.ret == pytest.ExitCode.TESTS_FAILED
+    assert_outcomes(result, passed=0, failed=1, rerun=0)
+
+
+@pytest.mark.skipif(not has_xdist, reason="requires xdist")
+def test_xdist_negative_marker_does_not_skip_initial_execution(testdir):
+    testdir.makepyfile(
+        """
+        import pytest
+
+        @pytest.mark.flaky(reruns=-1)
+        def test_fail():
+            assert False
+        """
+    )
+
+    result = testdir.runpytest("-p", "xdist", "-n", "1")
+
+    assert result.ret == pytest.ExitCode.TESTS_FAILED
+    assert_outcomes(result, passed=0, failed=1, rerun=0)
+
+
 def test_reruns_mode_append_sums_marker_and_cli(testdir):
     testdir.makepyfile(
         """


### PR DESCRIPTION
Fixes #359.

Negative rerun counts could skip the test entirely, because the rerun limit was checked before the first run.

This change ensures that the initial test execution is never suppressed by the rerun count.
Negative values no longer produce a false success without running the test.

Regression tests cover the supported rerun configuration sources, and also the distributed StatusDB path with xdist.
I also ran some local A/B checks for non-negative rerun counts, xdist worker crashes, exclusions, and other negative values.
