### PR TITLE
ci: test the free-threaded Python 3.14 build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,6 +96,39 @@ jobs:
       - name: Tests
         run: pytest
 
+  freethreading:
+    # The free-threaded build is officially supported since Python 3.14 (PEP 779).
+    # The plugin coordinates reruns between xdist workers over a socket server
+    # with a thread per connection, so run the suite without the GIL to make
+    # sure that shared state stays safe.
+    name: free-threading:py-3.14t:pytest-9.1
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.14t"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install -U pip
+          python -m pip install pytest==9.1.* pytest-xdist
+          python -m pip install -e .
+
+      - name: Verify the GIL stays disabled
+        # Importing an extension that does not declare free-threading support
+        # re-enables the GIL, which would make this job silently pointless.
+        run: |
+          python -c "
+          import sys, pytest, xdist, pytest_rerunfailures
+          assert not sys._is_gil_enabled(), 'importing the test dependencies re-enabled the GIL'
+          "
+
+      - name: Tests
+        run: pytest
+
   platform:
     # Test devel setup on different platforms.
     name: Platform-${{ matrix.os }}

--- a/changes/361.misc.rst
+++ b/changes/361.misc.rst
@@ -1,0 +1,1 @@
+Test the free-threaded Python 3.14 build in CI, via a new ``py314t`` tox environment and a matching workflow job.

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ envlist =
     linting
     py{310,311,312,313,314,py3}-pytest{82,83,84,90,91,main}
     py314-pytest91-xdist
+    py314t-pytest91-xdist
     docs
 minversion = 4.0
 


### PR DESCRIPTION
Free threading is officially supported as of Python 3.14 (PEP 779), but the
free-threaded build is not exercised anywhere in CI right now.

This matters more here than for a typical pure-Python package. Under xdist the
master runs a `ServerStatusDB` that workers connect to over a socket
(`src/pytest_rerunfailures.py` L597-605); the server itself runs in a background
thread (L785-786) and spawns a thread per worker connection (L795-797), with
shared state guarded by `_suite_lock` (L686). That is real concurrency, and it
has never been run without the GIL.

Changes:

- a `py314t-pytest91-xdist` tox environment
- a `free-threading:py-3.14t:pytest-9.1` CI job, structured as a copy of the
  existing `xdist` job — that one also installs dependencies with pip rather
  than going through tox, so this mirrors the existing convention
- the job asserts `sys._is_gil_enabled()` is false after importing pytest,
  xdist and the plugin, so it fails loudly instead of silently testing an
  interpreter that quietly re-enabled the GIL

Verified locally on a real GIL-disabled interpreter (`Py_GIL_DISABLED=1`,
`sys._is_gil_enabled()` returns False): `tox -e py314t-pytest91-xdist` gives
201 passed. `tox -e linting` is green.

Deliberately left out: the `Free Threading` trove classifier. Advertising
support in the same PR that starts testing it felt premature — happy to send
that separately once this job has been green for a while.

Unrelated, noticed while working on this: `allow-prereleases: true` in the
existing 3.14 jobs is now a no-op, since 3.14 is marked stable in
actions/python-versions. Happy to clean that up in a follow-up if useful.

Worked on this with Claude as an assistant; the reasoning above is mine
and I ran everything locally.
